### PR TITLE
fix(formatter): do not insert padding in blankline

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -319,4 +319,33 @@ describe('formatter', () => {
         assert.equal(result, expected);
       });
   });
+
+  // refs: https://github.com/shufo/blade-formatter/issues/48
+  test('it should not pad original blankline', async () => {
+    const content = [
+      `@section('content')`,
+      `<div class="content-header">`,
+      `<div>@php echo 'FOO'; @endphp</div>`,
+      ``, // blankline
+      `</div>`,
+      `@endsection`,
+      '',
+    ].join('\n');
+
+    const expected = [
+      `@section('content')`,
+      `    <div class="content-header">`,
+      `        <div>@php echo 'FOO'; @endphp</div>`,
+      ``, // should be keep original line
+      `    </div>`,
+      `@endsection`,
+      '',
+    ].join('\n');
+
+    return formatter()
+      .formatContent(content)
+      .then(result => {
+        assert.equal(result, expected);
+      });
+  });
 });

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -154,7 +154,16 @@ export default class Formatter {
     );
 
     const formattedLine = indentWhiteSpace + originalLine;
-    this.result.push(formattedLine);
+
+    // blankline
+    if (originalLine.length === 0) {
+      this.result.push(originalLine);
+    }
+
+    // formatted line
+    if (originalLine.length !== 0 && formattedLine.length > 0) {
+      this.result.push(formattedLine);
+    }
 
     if (formattedLine !== originalLine) {
       this.diffs.push({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pr fixes #48 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #48 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
keeping indentation on formatted lines causes padding insert

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see test
