### PR TITLE
fix: 🐛 preserve embedded php tags in original content

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -349,7 +349,7 @@ describe('formatter', () => {
       });
   });
 
-  test('preserve multiline php tag #57', async() => {
+  test('preserve multiline php tag #57', async () => {
     const content = [
       `<?php`,
       `/**`,
@@ -383,9 +383,9 @@ describe('formatter', () => {
       .then((result) => {
         assert.equal(result, expected);
       });
-    });
+  });
 
-  test('preserve inline php tag #57', async() => {
+  test('preserve inline php tag #57', async () => {
     const content = [
       `<body data-app="<?php echo json_encode($array); ?>"`,
       '',
@@ -403,7 +403,7 @@ describe('formatter', () => {
       });
   });
 
-  test('preserve inline php tag in script', async() => {
+  test('preserve inline php tag in script', async () => {
     const content = [
       `<script>`,
       `    var app = <?php echo json_encode($array); ?>;`,
@@ -425,8 +425,7 @@ describe('formatter', () => {
       });
   });
 
-
-  test('should be ignore short tag #56', async() => {
+  test('should be ignore short tag #56', async () => {
     const content = [
       `<table>`,
       `<th><?= $userName ?></th>`,

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -348,4 +348,103 @@ describe('formatter', () => {
         assert.equal(result, expected);
       });
   });
+
+  test('preserve multiline php tag #57', async() => {
+    const content = [
+      `<?php`,
+      `/**`,
+      ` * @var \Modules\Common\PageDataBuilderV2\RenderableItems\Card $card`,
+      ` */`,
+      `?>`,
+      `@extends('layouts.mainLayout')`,
+      ``,
+      `@section('someBlock')`,
+      ``,
+      `@endsection`,
+      '',
+    ].join('\n');
+
+    const expected = [
+      `<?php`,
+      `/**`,
+      ` * @var \Modules\Common\PageDataBuilderV2\RenderableItems\Card $card`,
+      ` */`,
+      `?>`,
+      `@extends('layouts.mainLayout')`,
+      ``,
+      `@section('someBlock')`,
+      ``,
+      `@endsection`,
+      '',
+    ].join('\n');
+
+    return formatter()
+      .formatContent(content)
+      .then((result) => {
+        assert.equal(result, expected);
+      });
+    });
+
+  test('preserve inline php tag #57', async() => {
+    const content = [
+      `<body data-app="<?php echo json_encode($array); ?>"`,
+      '',
+    ].join('\n');
+
+    const expected = [
+      `<body data-app="<?php echo json_encode($array); ?>"`,
+      '',
+    ].join('\n');
+
+    return formatter()
+      .formatContent(content)
+      .then((result) => {
+        assert.equal(result, expected);
+      });
+  });
+
+  test('preserve inline php tag in script', async() => {
+    const content = [
+      `<script>`,
+      `    var app = <?php echo json_encode($array); ?>;`,
+      `</script>`,
+      '',
+    ].join('\n');
+
+    const expected = [
+      `<script>`,
+      `    var app = <?php echo json_encode($array); ?>;`,
+      `</script>`,
+      '',
+    ].join('\n');
+
+    return formatter()
+      .formatContent(content)
+      .then((result) => {
+        assert.equal(result, expected);
+      });
+  });
+
+
+  test('should be ignore short tag #56', async() => {
+    const content = [
+      `<table>`,
+      `<th><?= $userName ?></th>`,
+      `</table>`,
+      '',
+    ].join('\n');
+
+    const expected = [
+      `<table>`,
+      `    <th><?= $userName ?></th>`,
+      `</table>`,
+      '',
+    ].join('\n');
+
+    return formatter()
+      .formatContent(content)
+      .then((result) => {
+        assert.equal(result, expected);
+      });
+  });
 });

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -8,6 +8,7 @@ import {
 } from './indent';
 import * as util from './util';
 import * as vsctm from './vsctm';
+import { resolve } from 'app-root-path';
 
 const os = require('os');
 const beautify = require('js-beautify').html;
@@ -42,9 +43,13 @@ export default class Formatter {
       end_with_newline: util.optional(this.options).endWithNewline || true,
     };
 
-    const formatted = beautify(data, options);
+    const promise =
+      new Promise((resolve, reject) => resolve(data))
+      .then(data => util.preserveOriginalPhpTagInHtml(data))
+      .then(preserved => beautify(preserved, options))
+      .then(beautified => util.revertOriginalPhpTagInHtml(beautified));
 
-    return Promise.resolve(formatted);
+    return Promise.resolve(promise);
   }
 
   formatAsBlade(content) {

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -8,7 +8,6 @@ import {
 } from './indent';
 import * as util from './util';
 import * as vsctm from './vsctm';
-import { resolve } from 'app-root-path';
 
 const os = require('os');
 const beautify = require('js-beautify').html;
@@ -43,11 +42,10 @@ export default class Formatter {
       end_with_newline: util.optional(this.options).endWithNewline || true,
     };
 
-    const promise =
-      new Promise((resolve, reject) => resolve(data))
-      .then(data => util.preserveOriginalPhpTagInHtml(data))
-      .then(preserved => beautify(preserved, options))
-      .then(beautified => util.revertOriginalPhpTagInHtml(beautified));
+    const promise = new Promise((resolve) => resolve(data))
+      .then((content) => util.preserveOriginalPhpTagInHtml(content))
+      .then((preserved) => beautify(preserved, options))
+      .then((beautified) => util.revertOriginalPhpTagInHtml(beautified));
 
     return Promise.resolve(promise);
   }

--- a/src/util.js
+++ b/src/util.js
@@ -71,10 +71,10 @@ export function generateDiff(path, originalLines, formattedLines) {
 }
 
 export function prettifyPhpContentWithUnescapedTags(content) {
-  let prettified = _.replace(content, /\{\{--/g, '<?php //');
-  prettified = _.replace(prettified, /--\}\}/g, '// ?>');
-  prettified = _.replace(prettified, /\{\{/g, '<?php ');
-  prettified = _.replace(prettified, /\}\}/g, ' ?>');
+  let prettified = _.replace(content, /\{\{--/g, '<?php /*comment*/');
+  prettified = _.replace(prettified, /--\}\}/g, '/*comment*/ ?>');
+  prettified = _.replace(prettified, /\{\{/g, '<?php /*blade*/');
+  prettified = _.replace(prettified, /\}\}/g, '/*blade*/ ?>');
 
   prettified = prettier.format(prettified, {
     parser: 'php',
@@ -82,17 +82,17 @@ export function prettifyPhpContentWithUnescapedTags(content) {
     singleQuote: true,
   });
 
-  prettified = _.replace(prettified, /<\?php\s\/\//g, '{{--');
-  prettified = _.replace(prettified, /\/\/\s\?>/g, '--}}');
-  prettified = _.replace(prettified, /<\?php\s/g, '{{ ');
-  prettified = _.replace(prettified, /\s\?>/g, ' }}');
+  prettified = _.replace(prettified, /<\?php\s\/\*comment\*\//g, '{{--');
+  prettified = _.replace(prettified, /\/\*comment\*\/\s\?>/g, '--}}');
+  prettified = _.replace(prettified, /<\?php\s\/\*blade\*\/\s/g, '{{ ');
+  prettified = _.replace(prettified, /\/\*blade\*\/\s\?>/g, ' }}');
 
   return prettified;
 }
 
 export function prettifyPhpContentWithEscapedTags(content) {
-  let prettified = _.replace(content, /{!!/g, '<?php ');
-  prettified = _.replace(prettified, /!!}/g, ' ?>');
+  let prettified = _.replace(content, /{!!/g, '<?php /*escaped*/');
+  prettified = _.replace(prettified, /!!}/g, '/*escaped*/ ?>');
 
   prettified = prettier.format(prettified, {
     parser: 'php',
@@ -100,14 +100,15 @@ export function prettifyPhpContentWithEscapedTags(content) {
     singleQuote: true,
   });
 
-  prettified = _.replace(prettified, /<\?php\s/g, '{!! ');
-  prettified = _.replace(prettified, /\s\?>/g, ' !!}');
+  prettified = _.replace(prettified, /<\?php\s\/\*escaped\*\//g, '{!! ');
+  prettified = _.replace(prettified, /\/\*escaped\*\/\s\?>/g, ' !!}');
+
   return prettified;
 }
 
 export function removeSemicolon(content) {
-  let prettified = _.replace(content, /;\s\}\}/g, ' }}');
-  prettified = _.replace(prettified, /;\s!!\}/g, ' !!}');
+  let prettified = _.replace(content, /;\n.*!!\}/g, ' !!}');
+  prettified = _.replace(prettified, /;\n.*}}/g, ' }}');
 
   return prettified;
 }
@@ -118,6 +119,21 @@ export function formatAsPhp(content) {
   prettified = removeSemicolon(prettified);
 
   return Promise.resolve(prettified);
+}
+
+export function preserveOriginalPhpTagInHtml(content) {
+  let prettified = _.replace(content, /<\?php/g, '/* <?php */');
+  prettified = _.replace(prettified, /\?>/g, '/* ?> */');
+
+  return prettified;
+}
+
+export function revertOriginalPhpTagInHtml(content) {
+  let prettified = _.replace(content, /\/\* <\?php \*\//g, '<?php');
+  prettified = _.replace(prettified, /\/\* \?> \*\/\s;\n/g, '?>;');
+  prettified = _.replace(prettified, /\/\* \?> \*\//g, '?>');
+
+  return prettified;
 }
 
 export function printDescription() {


### PR DESCRIPTION
fixes #56, fixes #57

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes behaviour that embedded php tags in original content unexpectedly removed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
see #56, #57

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See tests.
