### PR TITLE
fix: 🐛 do not remove original php tag

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -718,4 +718,40 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('should remain tags even if php tag exists vscode-blade-formattere#2', async () => {
+    const content = [
+      `<?php`,
+      `/* Some comments on this template`,
+      ` */`,
+      `?>`,
+      `<div class="font-ext-links">`,
+      `    <a class="btn btn-cta" href="{{ url('download/' . $font->slug) }}" title="Download {{ $font->title }}">`,
+      `        <i class="fa fa-fw fa-download"></i>`,
+      `        Download`,
+      `    </a>`,
+      ``,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `<?php`,
+      `/* Some comments on this template`,
+      ` */`,
+      `?>`,
+      `<div class="font-ext-links">`,
+      `    <a class="btn btn-cta" href="{{ url('download/' . $font->slug) }}" title="Download {{ $font->title }}">`,
+      `        <i class="fa fa-fw fa-download"></i>`,
+      `        Download`,
+      `    </a>`,
+      ``,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -110,7 +110,7 @@ export async function prettifyPhpContentWithUnescapedTags(content) {
       (res) =>
         _.replace(
           res,
-          /<\?php.*?\/\*blade\*\/\s(.*?)\s\/\*blade\*\/.*?\?>/gs,
+          /<\?php[\s\n]*?\/\*blade\*\/\s(.*?)\s\/\*blade\*\/[\s\n]*?\?>/gs,
           (match, p1) => {
             return `{{ ${p1} }}`.replace(/([\n\s]*)->([\n\s]*)/gs, '->');
           },


### PR DESCRIPTION
https://github.com/shufo/vscode-blade-formatter/issues/2

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes https://github.com/shufo/vscode-blade-formatter/issues/2

Unexpectedly Regexp removes tags between php open tag and blade brackets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see test

## Screenshots (if appropriate):
