### PR TITLE
fix: 🐛 unexpectedly remove tags after blade close expression

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -754,4 +754,22 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('should not format nbsp', async () => {
+    const content = [
+      `{{ trans('email.website_title') }}&nbsp;`,
+      `<a href="mailto:{{ trans('email.website_url') }}">{{ trans('email.website_url') }}</a>`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `{{ trans('email.website_title') }}&nbsp;`,
+      `<a href="mailto:{{ trans('email.website_url') }}">{{ trans('email.website_url') }}</a>`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -132,9 +132,9 @@ export async function removeSemicolon(content) {
   return new Promise((resolve) => {
     resolve(content);
   })
-    .then((res) => _.replace(res, /;\n.*!!\}/g, ' !!}'))
-    .then((res) => _.replace(res, /;.*?!!}/g, ' !!}'))
-    .then((res) => _.replace(res, /;\n.*}}/g, ' }}'))
+    .then((res) => _.replace(res, /;[\n\s]*!!\}/g, ' !!}'))
+    .then((res) => _.replace(res, /;[\s\n]*!!}/g, ' !!}'))
+    .then((res) => _.replace(res, /;[\n\s]*}}/g, ' }}'))
     .then((res) => _.replace(res, /; }}/g, ' }}'))
     .then((res) => _.replace(res, /; --}}/g, ' --}}'));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

code like below unexpectedly remove tags after blade close expression

```
    {{ trans('email.website_title') }}&nbsp;
    <a href="mailto:{{ trans('email.website_url') }}">{{ trans('email.website_url') }}</a>
```

will formatted to

```
    {{ trans('email.website_title') }}&nbsp;
```