### PR TITLE
fix: 🐛 regex to match balanced parentheses

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -772,4 +772,44 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('should not occurs error with if directive', async () => {
+    const content = [
+      `@if($user)`,
+      `    foo`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `@if($user)`,
+      `    foo`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
+
+  test('should not occurs error on directive inside html tag ', async () => {
+    const content = [
+      `<body class="hold-transition login-page"`,
+      `    @if(config('admin.login_background_image'))style="background: url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;"`,
+      `    @endif>`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `<body class="hold-transition login-page"`,
+      `    @if(config('admin.login_background_image'))style="background: url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;"`,
+      `    @endif>`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -802,4 +802,24 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('should not occurs error even if 3 level nested in directive', async () => {
+    const content = [
+      `@if(config('app.foo', env('APP_FOO_BAR')))`,
+      `    foo`,
+      `@endif>`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `@if(config('app.foo', env('APP_FOO_BAR')))`,
+      `    foo`,
+      `@endif>`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -774,19 +774,9 @@ describe('formatter', () => {
   });
 
   test('should not occurs error with if directive', async () => {
-    const content = [
-      `@if($user)`,
-      `    foo`,
-      `@endif`,
-      ``,
-    ].join('\n');
+    const content = [`@if($user)`, `    foo`, `@endif`, ``].join('\n');
 
-    const expected = [
-      `@if($user)`,
-      `    foo`,
-      `@endif`,
-      ``,
-    ].join('\n');
+    const expected = [`@if($user)`, `    foo`, `@endif`, ``].join('\n');
 
     return new BladeFormatter().format(content).then((result) => {
       assert.equal(result, expected);

--- a/src/util.js
+++ b/src/util.js
@@ -86,7 +86,7 @@ export async function prettifyPhpContentWithUnescapedTags(content) {
 
   const directiveRegexes = new RegExp(
     // eslint-disable-next-line max-len
-    `(?!\\/\\*.*?\\*\\/)(${directives})\\s*?(\\((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*\\))`,
+    `(?!\\/\\*.*?\\*\\/)(${directives})\\s*?\\(((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*)\\)`,
     'gm',
   );
 

--- a/src/util.js
+++ b/src/util.js
@@ -85,6 +85,7 @@ export async function prettifyPhpContentWithUnescapedTags(content) {
   const directives = _.without(indentStartTokens, '@switch').join('|');
 
   const directiveRegexes = new RegExp(
+    // eslint-disable-next-line max-len
     `(?!\\/\\*.*?\\*\\/)(${directives})\\s*?(\\((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*\\))`,
     'gm',
   );

--- a/src/util.js
+++ b/src/util.js
@@ -85,7 +85,7 @@ export async function prettifyPhpContentWithUnescapedTags(content) {
   const directives = _.without(indentStartTokens, '@switch').join('|');
 
   const directiveRegexes = new RegExp(
-    `(?!\\/\\*.*?\\*\\/)(${directives})\\s*?\\((.*)\\)`,
+    `(?!\\/\\*.*?\\*\\/)(${directives})\\s*?(\\((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*\\))`,
     'gm',
   );
 


### PR DESCRIPTION
 ## Description
<!--- Describe your changes in detail -->

fixes bug related to nested function in directive

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

refs #113 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests