### PR TITLE
fix: 🐛 ignore forelse directive for formatting

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -822,4 +822,28 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('forelse directive should work', async () => {
+    const content = [
+      `@forelse($students as $student)`,
+      `<div>foo</div>`,
+      `@empty`,
+      `empty`,
+      `@endforelse`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `@forelse($students as $student)`,
+      `    <div>foo</div>`,
+      `@empty`,
+      `    empty`,
+      `@endforelse`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -82,7 +82,9 @@ export function generateDiff(path, originalLines, formattedLines) {
 }
 
 export async function prettifyPhpContentWithUnescapedTags(content) {
-  const directives = _.without(indentStartTokens, '@switch').join('|');
+  const directives = _.without(indentStartTokens, '@switch', '@forelse').join(
+    '|',
+  );
 
   const directiveRegexes = new RegExp(
     // eslint-disable-next-line max-len


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

forelse directive occurs error on formamt

```php
'Parse Error : syntax error, unexpected \'as\' (T_AS), expecting \')\' on line 1\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39m\u001b[33m<\u001b[39m\u001b[33m?\u001b[39mphp forelse($students as $student) \u001b[33m?\u001b[39m\u001b[33m>\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m   | \u001b[39m                       \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m',
```
