### PR TITLE
feat: 🎸 support stdin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
 |`--indent-size`, `-i`|Indentation size|4|
 |`--wrap-line-length`, `--wrap`|The length of line wrap size|120|
 |`--end-with-newline`, `-e`|End output with newline|true|
+|`--stdin`|format code provided on `<STDIN>` |false|
 |`--help`, `-h`|Show help||
 |`--version`, `-v`|Show version||
 

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const os = require('os');
 const cmd = require('./support/cmd');
 const util = require('./support/util');
+const { spawnSync } = require('child_process');
 
 describe('The blade formatter CLI', () => {
   test('should print the help', async function () {
@@ -238,6 +239,30 @@ describe('The blade formatter CLI', () => {
         '__tests__',
         'fixtures',
         'formatted.if_nest.blade.php',
+      ),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test('stdin option', async () => {
+    const cmdResult = await spawnSync(
+      '/bin/cat',
+      [
+        '__tests__/fixtures/index.blade.php',
+        '|',
+        './bin/blade-formatter',
+        '--stdin',
+      ],
+      { stdio: 'pipe', shell: true },
+    ).stdout.toString();
+
+    const formatted = fs.readFileSync(
+      path.resolve(
+        __basedir,
+        '__tests__',
+        'fixtures',
+        'formatted.index.blade.php',
       ),
     );
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@prettier/plugin-php": "^0.14.0",
     "chalk": "^4.1.0",
+    "concat-stream": "^2.0.0",
     "detect-indent": "^6.0.0",
     "esm": "^3.2.25",
     "glob": "^7.1.4",
@@ -42,7 +43,6 @@
     "@babel/preset-env": "^7.6.3",
     "app-root-path": "^3.0.0",
     "babel-jest": "^26.1.0",
-    "concat-stream": "^2.0.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.4.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import concat from 'concat-stream';
 import { BladeFormatter } from './main';
 
 export default async function cli() {
@@ -50,9 +51,25 @@ export default async function cli() {
       description: 'Print progress',
       default: false,
     })
+    .option('stdin', {
+      type: 'boolean',
+      description: 'format code provided on <STDIN>',
+      default: false,
+    })
     .help('h')
     .alias('h', 'help')
     .epilog('Copyright Shuhei Hayashibara 2019').argv;
+
+  if (argv.stdin) {
+    await process.stdin.pipe(
+      concat({ encoding: 'string' }, (text) => {
+        return new BladeFormatter(argv)
+          .format(text)
+          .then((result) => process.stdout.write(result));
+      }),
+    );
+    return;
+  }
 
   if (argv._.length === 0) {
     yargs.showHelp();


### PR DESCRIPTION
#123 #110

✅ Closes: #123 

## Description
This PR adds a feature for stdin support.

## Motivation and Context
stdin support enables communication with other processes more easier.
After this PR merged, `--stdin` option will be enabled.

```bash
cat test.blade.php | ./node_modules/.bin/blade-formatter --stdin
```