### PR TITLE
fix: raw php constant expression causes parse error

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1238,4 +1238,23 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  const predefinnedConstants = [
+    'PHP_VERSION',
+    'PHP_RELEASE_VERSION',
+    'PHP_VERSION_ID',
+    'PHP_OS_FAMILY',
+    'PHP_FLOAT_DIG',
+  ];
+
+  predefinnedConstants.forEach((constant) => {
+    test('should format php predefined constants', async () => {
+      const content = [`{{ ${constant} }}`].join('\n');
+      const expected = [`{{ ${constant} }}`, ''].join('\n');
+
+      return new BladeFormatter().format(content).then((result) => {
+        assert.equal(result, expected);
+      });
+    });
+  });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -49,13 +49,13 @@ export function formatStringAsPhp(content) {
 
 export function formatRawStringAsPhp(content) {
   return prettier
-    .format(`<?php ${content} ?>`, {
+    .format(`<?php echo ${content} ?>`, {
       parser: 'php',
       printWidth: 1000,
       singleQuote: true,
       phpVersion: '7.4',
     })
-    .replace(/<\?php(.*)?\?>/gs, (match, p1) => {
+    .replace(/<\?php echo (.*)?\?>/gs, (match, p1) => {
       return p1.trim().replace(/;\s*$/, '');
     });
 }


### PR DESCRIPTION
- fix: 🐛 echo php expressionn
- test: 💍 add test for php predefined constant echo

<!--- Provide a general summary of your changes in the Title above -->
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/shufo/vscode-blade-formatter/issues/64
