### PR TITLE
feat: support php 8 syntax

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1269,4 +1269,19 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('should format named arguments', async () => {
+    const content = [
+      `{{ htmlspecialchars($string,  double_encode:  false) }}`,
+    ].join('\n');
+
+    const expected = [
+      `{{ htmlspecialchars($string, double_encode: false) }}`,
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1257,4 +1257,16 @@ describe('formatter', () => {
       });
     });
   });
+
+  test('should format null safe operator', async () => {
+    const content = [`{{ $entity->executors->first()?->name() }}`].join('\n');
+
+    const expected = [`{{ $entity->executors->first()?->name() }}`, ``].join(
+      '\n',
+    );
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Shuhei Hayashibara",
   "license": "MIT",
   "dependencies": {
-    "@prettier/plugin-php": "^0.16.0",
+    "@prettier/plugin-php": "prettier/plugin-php#ed00e2a07851cfacba0f8648dc7b209be6b9e6b9",
     "chalk": "^4.1.0",
     "concat-stream": "^2.0.0",
     "detect-indent": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,7 +1165,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@prettier/plugin-php@^0.16.0":
+"@prettier/plugin-php@^0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@prettier/plugin-php/-/plugin-php-0.16.1.tgz#0255749fe1a36c00c7ddc049ec8dc2928a8ac512"
   integrity sha512-U0G5MnWEw3H4o53ZKmIDNBAN9w/7jkiFAhWPG6DJ+FyB9RmdhDouW05wLq8UraxjigzmXNZzT+ZQor697iW9Hg==
@@ -1173,6 +1173,14 @@
     linguist-languages "^7.5.1"
     mem "^8.0.0"
     php-parser "3.0.2"
+
+"@prettier/plugin-php@prettier/plugin-php#ed00e2a07851cfacba0f8648dc7b209be6b9e6b9":
+  version "0.16.1"
+  resolved "https://codeload.github.com/prettier/plugin-php/tar.gz/ed00e2a07851cfacba0f8648dc7b209be6b9e6b9"
+  dependencies:
+    linguist-languages "^7.5.1"
+    mem "^8.0.0"
+    php-parser czosel/php-parser#b55446b48a4a588e8b62c7f9085ce0e7cb3b70fa
 
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
@@ -4307,6 +4315,10 @@ php-parser@3.0.2, php-parser@^3.0.0-prerelease.9:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.2.tgz#a86dbbc110e57378cba71ab4cd9b0d18f3872ac3"
   integrity sha512-a7y1+odEGsceLDLpu7oNyspZ0pK8FMWJOoim4/yd82AtnEZNLdCLZ67arnOQZ9K0lHJiSp4/7lVUpGELVxE14w==
+
+php-parser@czosel/php-parser#b55446b48a4a588e8b62c7f9085ce0e7cb3b70fa:
+  version "3.0.2"
+  resolved "https://codeload.github.com/czosel/php-parser/tar.gz/b55446b48a4a588e8b62c7f9085ce0e7cb3b70fa"
 
 picomatch@^2.0.4, picomatch@^2.0.5:
   version "2.2.1"


### PR DESCRIPTION
- feat: 🎸 bump plugin-php to php 8 supported version (wip)
- test: 💍 add test for null safe operator

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- This PR will add support for php 8 syntax
  - null safe operator
  e.g.
  ```php
  {{ $entity->executors->first()?->name() }}
  ```
  - named arguments
  e.g.
  ```php
  {{ htmlspecialchars($string, double_encode: false) }}
  ```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/75
- https://github.com/shufo/vscode-blade-formatter/issues/61

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see added tests
