### PR TITLE
fix: 🐛 adjust indent level for directive in scripts

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -493,4 +493,29 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent('complicated directive in script tag', async () => {
+    const cmdResult = await cmd.execute(
+      path.resolve(__basedir, 'bin', 'blade-formatter'),
+      [
+        path.resolve(
+          __basedir,
+          '__tests__',
+          'fixtures',
+          'directive_in_scripts_complex.blade.php',
+        ),
+      ],
+    );
+
+    const formatted = fs.readFileSync(
+      path.resolve(
+        __basedir,
+        '__tests__',
+        'fixtures',
+        'formatted.directive_in_scripts_complex.blade.php',
+      ),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/fixtures/directive_in_scripts_complex.blade.php
+++ b/__tests__/fixtures/directive_in_scripts_complex.blade.php
@@ -1,0 +1,59 @@
+@push('scripts')
+<script src="{{ asset('backend/plugins/dropzone/dropzone.min.js') }}"></script>
+    <script>
+    Dropzone.options.gallery = {
+       url: "...",
+       previewTemplate: $("#preview-template").html(),
+       dictDefaultMessage: "Drop files here or click to select",
+            addRemoveLinks: true,
+            uploadMultiple: true,
+            maxFilesize: 2,
+       filesizeBase: 1024,
+            acceptedFiles: "image/jpg,image/jpeg,image/png",
+            init: function() {
+            this.renderExistingServerFiles = function(files, fileUrls, response) {
+                for (const file in files) {
+                        if (Object.hasOwnProperty.call(files, file)) {
+                            const element = files[file];
+
+                            this.files.push(element);
+                            this.displayExistingFile(element, fileUrls[file], null, null, true);
+                            this.emit("processing", element);
+                            this.emit("complete", element);
+                        }
+                    }
+                this.emit("successmultiple", files, response, false);
+                }
+
+           @isset($item->images)
+     let files = [];
+        let fileUrls = [];
+     let response = { status:"success", fileHashes: [], imageIds: []};
+     @foreach ($item->images as $image)
+        @php
+                $imageUrl = asset('img/' . $image->image_hash);
+          $imagePath = public_path('img/' . $image->image_hash);
+                $imageMime = File::mimeType($imagePath);
+                $imageSize = File::size($imagePath);
+                $imageName = File::name($imagePath);
+            @endphp
+
+            files.push({
+            processing: true,
+            accepted: true,
+            name: "{{ $imageName }}",
+        size: {{ $imageSize }},
+            type: '{{ $imageMime }}',
+            status: Dropzone.SUCCESS,});
+
+        fileUrls.push("{{ $imageUrl }}")
+        response.fileHashes.push("{{ $image->image_hash }}")
+            response.imageIds.push("{{ $image->id }}")
+    @endforeach
+        this.renderExistingServerFiles(files, fileUrls, response);
+    @endisset
+            },
+        }
+
+    </script>
+@endpush

--- a/__tests__/fixtures/formatted.directive_in_scripts_complex.blade.php
+++ b/__tests__/fixtures/formatted.directive_in_scripts_complex.blade.php
@@ -1,0 +1,59 @@
+@push('scripts')
+    <script src="{{ asset('backend/plugins/dropzone/dropzone.min.js') }}"></script>
+    <script>
+        Dropzone.options.gallery = {
+            url: "...",
+            previewTemplate: $("#preview-template").html(),
+            dictDefaultMessage: "Drop files here or click to select",
+            addRemoveLinks: true,
+            uploadMultiple: true,
+            maxFilesize: 2,
+            filesizeBase: 1024,
+            acceptedFiles: "image/jpg,image/jpeg,image/png",
+            init: function() {
+                this.renderExistingServerFiles = function(files, fileUrls, response) {
+                    for (const file in files) {
+                        if (Object.hasOwnProperty.call(files, file)) {
+                            const element = files[file];
+
+                            this.files.push(element);
+                            this.displayExistingFile(element, fileUrls[file], null, null, true);
+                            this.emit("processing", element);
+                            this.emit("complete", element);
+                        }
+                    }
+                    this.emit("successmultiple", files, response, false);
+                }
+
+                @isset($item->images)
+                    let files = [];
+                    let fileUrls = [];
+                    let response = { status:"success", fileHashes: [], imageIds: []};
+                    @foreach ($item->images as $image)
+                        @php
+                            $imageUrl = asset('img/' . $image->image_hash);
+                            $imagePath = public_path('img/' . $image->image_hash);
+                            $imageMime = File::mimeType($imagePath);
+                            $imageSize = File::size($imagePath);
+                            $imageName = File::name($imagePath);
+                        @endphp
+                    
+                        files.push({
+                        processing: true,
+                        accepted: true,
+                        name: "{{ $imageName }}",
+                        size: {{ $imageSize }},
+                        type: '{{ $imageMime }}',
+                        status: Dropzone.SUCCESS,});
+                    
+                        fileUrls.push("{{ $imageUrl }}")
+                        response.fileHashes.push("{{ $image->image_hash }}")
+                        response.imageIds.push("{{ $image->id }}")
+                    @endforeach
+                    this.renderExistingServerFiles(files, fileUrls, response);
+                @endisset
+            },
+        }
+
+    </script>
+@endpush

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -336,7 +336,7 @@ export default class Formatter {
       .join('\n');
   }
 
-  indentBladeDirectiveBlock(spaces, content, scriptIndentLevel) {
+  indentBladeDirectiveBlock(spaces, content) {
     if (_.isEmpty(spaces)) {
       return content;
     }


### PR DESCRIPTION
- refs: https://github.com/shufo/vscode-blade-formatter/issues/47

## Description
<!--- Describe your changes in detail -->
- fixes indentation problem in directive in script tags like below causes unexpected format error

```blade
@push('scripts')
    <script src="{{ asset('backend/plugins/dropzone/dropzone.min.js') }}"></script>
    <script>
        Dropzone.options.gallery = {
            url: "...",
            previewTemplate: $("#preview-template").html(),
            dictDefaultMessage: "Drop files here or click to select",
            addRemoveLinks: true,
            uploadMultiple: true,
            maxFilesize: 2,
            filesizeBase: 1024,
            acceptedFiles: "image/jpg,image/jpeg,image/png",
            init: function() {
                this.renderExistingServerFiles = function(files, fileUrls, response) {
                    for (const file in files) {
                        if (Object.hasOwnProperty.call(files, file)) {
                            const element = files[file];

                            this.files.push(element);
                            this.displayExistingFile(element, fileUrls[file], null, null, true);
                            this.emit("processing", element);
                            this.emit("complete", element);
                        }
                    }
                    this.emit("successmultiple", files, response, false);
                }

                @isset($item->images)
                    let files = [];
                    let fileUrls = [];
                    let response = { status:"success", fileHashes: [], imageIds: []};
                    @foreach ($item->images as $image)
                        @php
                            $imageUrl = asset('img/' . $image->image_hash);
                            $imagePath = public_path('img/' . $image->image_hash);
                            $imageMime = File::mimeType($imagePath);
                            $imageSize = File::size($imagePath);
                            $imageName = File::name($imagePath);
                        @endphp
                    
                        files.push({
                        processing: true,
                        accepted: true,
                        name: "{{ $imageName }}",
                        size: {{ $imageSize }},
                        type: '{{ $imageMime }}',
                        status: Dropzone.SUCCESS,});
                    
                        fileUrls.push("{{ $imageUrl }}")
                        response.fileHashes.push("{{ $image->image_hash }}")
                        response.imageIds.push("{{ $image->id }}")
                    @endforeach
                    this.renderExistingServerFiles(files, fileUrls, response);
                @endisset
            },
        }

    </script>
@endpush

```

## Related Issue
- https://github.com/shufo/vscode-blade-formatter/issues/47

## Tests
see test fixture template