### PR TITLE
fix: break chained method in directive

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1405,4 +1405,44 @@ describe('formatter', () => {
         });
     });
   });
+
+  test('should break chained method in directive', async () => {
+    const content = [
+      '@if (auth()',
+      '->user()',
+      "->subscribed('default'))",
+      'aaa',
+      '@endif',
+    ].join('\n');
+
+    const expected = [
+      "@if (auth()->user()->subscribed('default'))",
+      '    aaa',
+      '@endif',
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
+
+  test('should break chained method in directive 2', async () => {
+    const content = [
+      '@foreach (request()->users() as $user)',
+      'aaa',
+      '@endif',
+    ].join('\n');
+
+    const expected = [
+      '@foreach (request()->users() as $user)',
+      '    aaa',
+      '@endif',
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -113,14 +113,14 @@ export async function prettifyPhpContentWithUnescapedTags(content) {
   return new Promise((resolve) => resolve(content))
     .then((res) =>
       _.replace(res, directiveRegexes, (match, p1, p2, p3) => {
-        return formatStringAsPhp(
-          `<?php ${p1.substr('1')}${p2}(${p3}) ?>`,
-        ).replace(
-          /<\?php\s(.*?)(\s*?)\((.*?)\);*\s\?>\n/gs,
-          (match2, j1, j2, j3) => {
-            return `@${j1.trim()}${j2}(${j3.trim()})`;
-          },
-        );
+        return formatStringAsPhp(`<?php ${p1.substr('1')}${p2}(${p3}) ?>`)
+          .replace(
+            /<\?php\s(.*?)(\s*?)\((.*?)\);*\s\?>\n/gs,
+            (match2, j1, j2, j3) => {
+              return `@${j1.trim()}${j2}(${j3.trim()})`;
+            },
+          )
+          .replace(/([\n\s]*)->([\n\s]*)/gs, '->');
       }),
     )
     .then((res) => formatStringAsPhp(res));


### PR DESCRIPTION
- fix: 🐛 break chained method in directive
- test: 💍 add test for chained method in directive

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

chained method in directive like below

```blade
      "@if (auth()->user()->subscribed('default'))",
```

was unexpectedly break into

```blade
      "@if (auth()
          ->user()
          ->subscribed('default'))",
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/53

## Motivation
Expression in directive parenthesis should not break

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
