### PR TITLE
fix: 🐛 indent body inside case directive #209

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -518,4 +518,29 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent('case directive should be indented', async () => {
+    const cmdResult = await cmd.execute(
+      path.resolve(__basedir, 'bin', 'blade-formatter'),
+      [
+        path.resolve(
+          __basedir,
+          '__tests__',
+          'fixtures',
+          'case_directive.blade.php',
+        ),
+      ],
+    );
+
+    const formatted = fs.readFileSync(
+      path.resolve(
+        __basedir,
+        '__tests__',
+        'fixtures',
+        'formatted.case_directive.blade.php',
+      ),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/fixtures/case_directive.blade.php
+++ b/__tests__/fixtures/case_directive.blade.php
@@ -1,0 +1,12 @@
+@switch($i)
+  @case(1)
+           First case...
+                  @break
+       @case(2)
+           Second case...
+  @break
+        @default
+      Default case...
+            @endswitch
+
+    <input class="foo" type="text" />

--- a/__tests__/fixtures/formatted.case_directive.blade.php
+++ b/__tests__/fixtures/formatted.case_directive.blade.php
@@ -1,0 +1,12 @@
+@switch($i)
+    @case(1)
+        First case...
+    @break
+    @case(2)
+        Second case...
+    @break
+    @default
+        Default case...
+@endswitch
+
+<input class="foo" type="text" />

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -762,15 +762,15 @@ describe('formatter', () => {
     const expected = [
       `@switch($i)`,
       `    @case(1)`,
-      `    First case...`,
+      `        First case...`,
       `    @break`,
       ``,
       `    @case(2)`,
-      `    Second case...`,
+      `        Second case...`,
       `    @break`,
       ``,
       `    @default`,
-      `    Default case...`,
+      `        Default case...`,
       `@endswitch`,
       ``,
     ].join('\n');

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -8,7 +8,6 @@ import {
   hasStartAndEndToken,
   phpKeywordStartTokens,
   phpKeywordEndTokens,
-  inlineFunctionDirectives,
   indentStartAndEndTokens,
 } from './indent';
 import * as util from './util';

--- a/src/indent.js
+++ b/src/indent.js
@@ -95,8 +95,6 @@ export const phpKeywordEndTokens = [
   '@break',
 ];
 
-export const inlineFunctionDirectives = ['@json'];
-
 export function hasStartAndEndToken(tokenizeLineResult, originalLine) {
   return (
     _.filter(tokenizeLineResult.tokens, (tokenStruct) => {

--- a/src/indent.js
+++ b/src/indent.js
@@ -76,12 +76,15 @@ export const tokenForIndentStartOrElseTokens = ['@forelse'];
 
 export const indentStartOrElseTokens = ['@empty'];
 
+export const indentStartAndEndTokens = ['@default'];
+
 export const phpKeywordStartTokens = [
   '@if',
   '@for',
   '@foreach',
   '@while',
   '@sectionmissing',
+  '@case',
 ];
 
 export const phpKeywordEndTokens = [
@@ -89,7 +92,10 @@ export const phpKeywordEndTokens = [
   '@endfor',
   '@endforeach',
   '@endwhile',
+  '@break',
 ];
+
+export const inlineFunctionDirectives = ['@json'];
 
 export function hasStartAndEndToken(tokenizeLineResult, originalLine) {
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

CUrrently `@case` directive is unexpectedly formatted as flat structure.

```blade
    @switch($i)
        @case(1)
            First case...
        @break
        @case(2)
            Second case...
        @break
        @default
            Default case...
    @endswitch
```

will be formatted as

```blade
    @switch($i)
        @case(1)
        First case...
        @break
        @case(2)
        Second case...
        @break
        @default
        Default case...
    @endswitch
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: #209

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

body inside `@case` directive should be indented

## How Has This Been Tested?

see tests
