### PR TITLE
fix: 🐛 `@forelse` inside `@if` gets unexpected indentation #254

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1467,4 +1467,35 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('forelse inside if directive should work #254', async () => {
+    const content = [
+      '@if (true)',
+      '<table>',
+      '@forelse($elems as $elem)',
+      '<tr></tr>',
+      '@empty',
+      '<tr></tr>',
+      '@endforelse',
+      '</table>',
+      '@endif',
+    ].join('\n');
+
+    const expected = [
+      '@if (true)',
+      '    <table>',
+      '        @forelse($elems as $elem)',
+      '            <tr></tr>',
+      '        @empty',
+      '            <tr></tr>',
+      '        @endforelse',
+      '    </table>',
+      '@endif',
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  });
 });

--- a/src/indent.js
+++ b/src/indent.js
@@ -79,6 +79,7 @@ export const indentStartOrElseTokens = ['@empty'];
 export const indentStartAndEndTokens = ['@default'];
 
 export const phpKeywordStartTokens = [
+  '@forelse',
   '@if',
   '@for',
   '@foreach',
@@ -88,6 +89,7 @@ export const phpKeywordStartTokens = [
 ];
 
 export const phpKeywordEndTokens = [
+  '@endforelse',
   '@endif',
   '@endfor',
   '@endforeach',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- `@forelse` directive inside `@if` directive gets unexpected indentation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: #254

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
