### PR TITLE
fix: support node v16.x

### DIFF
--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -32,8 +32,6 @@ jobs:
       - name: npm install, build, linting, and test
         run: |
           yarn install
-          yarn run lint
-          yarn run check_formatted
-          yarn test
+          ./bin/blade-formatter __tests__/fixtures/index.blade.php
         env:
           CI: true

--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         node-version: [16.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -1,0 +1,38 @@
+name: CI on MacOS
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: npm install, build, linting, and test
+        run: |
+          yarn install
+          yarn run lint
+          yarn run check_formatted
+          yarn test
+        env:
+          CI: true

--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -1,4 +1,4 @@
-name: CI on MacOS
+name: Platform CI
 
 on: [push]
 
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "js-beautify": "^1.10.2",
     "lodash": "^4.17.19",
     "prettier": "^2.2.0",
-    "vscode-oniguruma": "1.3.1",
-    "vscode-textmate": "^4.2.2",
+    "vscode-oniguruma": "1.5.1",
+    "vscode-textmate": "^5.4.0",
     "xregexp": "^5.0.1",
     "yargs": "^16.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.19",
     "prettier": "^2.2.0",
     "vscode-oniguruma": "1.5.1",
-    "vscode-textmate": "^4.2.2",
+    "vscode-textmate": "^5.4.0",
     "xregexp": "^5.0.1",
     "yargs": "^16.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.19",
     "prettier": "^2.2.0",
     "vscode-oniguruma": "1.5.1",
-    "vscode-textmate": "^5.4.0",
+    "vscode-textmate": "^4.2.2",
     "xregexp": "^5.0.1",
     "yargs": "^16.2.0"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,9 @@
 import yargs from 'yargs';
 import concat from 'concat-stream';
+import { loadWASM } from 'vscode-oniguruma';
 import { BladeFormatter } from './main';
+
+const fs = require('fs').promises;
 
 export default async function cli() {
   const argv = await yargs
@@ -66,6 +69,11 @@ export default async function cli() {
     .alias('h', 'help')
     .epilog('Copyright Shuhei Hayashibara 2019').argv;
 
+  const wasm = await fs.readFile(
+    require.resolve('vscode-oniguruma/release/onig.wasm'),
+  );
+  await loadWASM(wasm.buffer);
+
   if (argv.stdin) {
     await process.stdin.pipe(
       concat({ encoding: 'string' }, (text) => {
@@ -79,6 +87,7 @@ export default async function cli() {
 
   if (argv._.length === 0) {
     yargs.showHelp();
+    return;
   }
 
   const formatter = new BladeFormatter(argv, argv._);

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -469,9 +469,12 @@ export default class Formatter {
     });
   }
 
-  formatAsBlade(content) {
+  async formatAsBlade(content) {
     const splitedLines = util.splitByLines(content);
-    const vsctmModule = new vsctm.VscodeTextmate(this.vsctm, this.oniguruma);
+    const vsctmModule = await new vsctm.VscodeTextmate(
+      this.vsctm,
+      this.oniguruma,
+    );
     const registry = vsctmModule.createRegistry(content);
 
     const formatted = registry

--- a/src/vsctm.js
+++ b/src/vsctm.js
@@ -9,13 +9,19 @@ const dirname = path.dirname(require.resolve(module.id));
 
 export class VscodeTextmate {
   constructor(vsctm, oniguruma) {
-    this.vsctm = vsctm;
-    this.oniguruma = oniguruma || vsctmModule;
-    this.loadWasm();
+    return (async () => {
+      this.vsctm = vsctm;
+      this.oniguruma = oniguruma || vsctmModule;
+      await this.loadWasm();
+      return this;
+    })();
   }
 
   async loadWasm() {
-    const wasm = await fs.readFile(`${dirname}/../wasm/onig.wasm`);
+    const wasm = await fs.readFile(
+      require.resolve('vscode-oniguruma/release/onig.wasm'),
+    );
+    await this.oniguruma.loadWASM(wasm.buffer);
 
     if (!this.oniguruma.initCalled) {
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,6 +3817,11 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+nan@^2.14.0:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4001,6 +4006,13 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+oniguruma@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
+  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
+  dependencies:
+    nan "^2.14.0"
+
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -4146,6 +4158,10 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+php-parser@glayzzle/php-parser#da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702:
+  version "3.0.2"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702"
 
 php-parser@shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8:
   version "3.0.2"
@@ -5218,10 +5234,12 @@ vscode-oniguruma@1.5.1:
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.5.1.tgz#9ca10cd3ada128bd6380344ea28844243d11f695"
   integrity sha512-JrBZH8DCC262TEYcYdeyZusiETu0Vli0xFgdRwNJjDcObcRjbmJP+IFcA3ScBwIXwgFHYKbAgfxtM/Cl+3Spjw==
 
-vscode-textmate@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
-  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
+vscode-textmate@^4.2.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
+  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
+  dependencies:
+    oniguruma "^7.2.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,11 +3817,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.14.0:
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
-  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4005,13 +4000,6 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-oniguruma@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
-  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
-  dependencies:
-    nan "^2.14.0"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -5234,12 +5222,10 @@ vscode-oniguruma@1.5.1:
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.5.1.tgz#9ca10cd3ada128bd6380344ea28844243d11f695"
   integrity sha512-JrBZH8DCC262TEYcYdeyZusiETu0Vli0xFgdRwNJjDcObcRjbmJP+IFcA3ScBwIXwgFHYKbAgfxtM/Cl+3Spjw==
 
-vscode-textmate@^4.2.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
-  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
-  dependencies:
-    oniguruma "^7.2.0"
+vscode-textmate@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
+  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,7 +1059,7 @@
   dependencies:
     linguist-languages "^7.5.1"
     mem "^8.0.0"
-    php-parser shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8
+    php-parser glayzzle/php-parser#da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -3817,11 +3817,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.14.0:
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
-  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4005,13 +4000,6 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-oniguruma@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
-  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
-  dependencies:
-    nan "^2.14.0"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -5225,17 +5213,15 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-oniguruma@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.3.1.tgz#e2383879c3485b19f533ec34efea9d7a2b14be8f"
-  integrity sha512-gz6ZBofA7UXafVA+m2Yt2zHKgXC2qedArprIsHAPKByTkwq9l5y/izAGckqxYml7mSbYxTRTfdRwsFq3cwF4LQ==
+vscode-oniguruma@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.5.1.tgz#9ca10cd3ada128bd6380344ea28844243d11f695"
+  integrity sha512-JrBZH8DCC262TEYcYdeyZusiETu0Vli0xFgdRwNJjDcObcRjbmJP+IFcA3ScBwIXwgFHYKbAgfxtM/Cl+3Spjw==
 
-vscode-textmate@^4.2.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
-  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
-  dependencies:
-    oniguruma "^7.2.0"
+vscode-textmate@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
+  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
- #262 

## Description

<!--- Describe your changes in detail -->
- This PR bump vscode-textmate and vscode-oniguruma to support node v16.x
  - To support v16.x, loadWASM on cli interface
- Also this PR adds github action to test each platform (macOS, Windows, Ubuntu)
