### PR TITLE
fix: templating string indentation behaviour in script tag

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -543,4 +543,45 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent(
+    'should not indent twice on multiline templating string in script tag #279',
+    async () => {
+      const cmdResult = await cmd.execute(
+        path.resolve(__basedir, 'bin', 'blade-formatter'),
+        [
+          path.resolve(
+            __basedir,
+            '__tests__',
+            'fixtures',
+            'multiline_templating_string_in_script_tag.blade.php',
+          ),
+        ],
+      );
+
+      const formatted = fs.readFileSync(
+        path.resolve(
+          __basedir,
+          '__tests__',
+          'fixtures',
+          'formatted.multiline_templating_string_in_script_tag.blade.php',
+        ),
+      );
+
+      expect(cmdResult).toEqual(formatted.toString('utf-8'));
+
+      const cmdResult2 = await cmd.execute(
+        path.resolve(__basedir, 'bin', 'blade-formatter'),
+        [
+          path.resolve(
+            __basedir,
+            '__tests__',
+            'fixtures',
+            'formatted.multiline_templating_string_in_script_tag.blade.php',
+          ),
+        ],
+      );
+      expect(cmdResult2).toEqual(formatted.toString('utf-8'));
+    },
+  );
 });

--- a/__tests__/fixtures/formatted.directive_in_scripts.blade.php
+++ b/__tests__/fixtures/formatted.directive_in_scripts.blade.php
@@ -53,5 +53,4 @@
         output = output + "</table>";
         document.write(output);
     }
-
 </script>

--- a/__tests__/fixtures/formatted.directive_in_scripts_complex.blade.php
+++ b/__tests__/fixtures/formatted.directive_in_scripts_complex.blade.php
@@ -54,6 +54,5 @@
                 @endisset
             },
         }
-
     </script>
 @endpush

--- a/__tests__/fixtures/formatted.escaped_bug.blade.php
+++ b/__tests__/fixtures/formatted.escaped_bug.blade.php
@@ -22,8 +22,7 @@
                 onclick="yaCounter.reachGoal('form'); return true;">{{ $face_btn_text }}</a>
           @endisset
           @isset($clutch)
-              <script type="text/javascript"
-                src="https://widget.clutch.co/static/js/widget.js">
+              <script type="text/javascript" src="https://widget.clutch.co/static/js/widget.js">
               </script>
               <div class="face__clutch clutch-widget"
                 data-url="https://widget.clutch.co" data-widget-type="2"

--- a/__tests__/fixtures/formatted.multiline_blade_comment.blade.php
+++ b/__tests__/fixtures/formatted.multiline_blade_comment.blade.php
@@ -57,5 +57,4 @@ this images is example --}}
         $('.original-image-input').val('');
         $('#preview_' + id_name).remove('');
     })
-
 </script>

--- a/__tests__/fixtures/formatted.multiline_templating_string_in_script_tag.blade.php
+++ b/__tests__/fixtures/formatted.multiline_templating_string_in_script_tag.blade.php
@@ -1,0 +1,14 @@
+@push('scripts')
+    <script>
+        const html = `<ul>
+                  <li>Coffee</li>
+                  <li>Tea</li>
+                  <li>Milk</li>
+                  </ul>`;
+
+        const foo = `<ul></ul>`;
+
+        const bar = `<ul>
+  </ul>`;
+    </script>
+@endpush

--- a/__tests__/fixtures/formatted_shorttag.blade.php
+++ b/__tests__/fixtures/formatted_shorttag.blade.php
@@ -188,8 +188,7 @@
                         a = t.find(u);
                     a.each(function() {
                         s = e(this);
-                        o = s.is("input[type=checkbox],input[type=radio]") ? s.is(":checked") : s
-                            .val();
+                        o = s.is("input[type=checkbox],input[type=radio]") ? s.is(":checked") : s.val();
                         if (!o === !r) {
                             if (s.is("input[type=radio]") && a.filter(
                                     'input[type=radio]:checked[name="' + s.attr("name") + '"]')
@@ -335,7 +334,6 @@
                 })
             }
         })(jQuery)
-
     </script>
     <style>
         a.status-1 {
@@ -349,8 +347,7 @@
             $.ajaxSetup({
                 beforeSend: function(xhr, settings) {
                     console.log('beforesend');
-                    settings.data +=
-                        "&_token=<?php echo csrf_token(); ?>";
+                    settings.data += "&_token=<?php echo csrf_token(); ?>";
                 }
             });
 
@@ -370,12 +367,12 @@
             $('.group-select').on('change', function() {
                 var group = $(this).val();
                 if (group) {
-                    window.location.href = '<?php echo action('\
-                    Barryvdh\ TranslationManager\ Controller @getView '); ?>/' + $(this)
-                        .val();
+                    window.location.href =
+                        '<?php echo action('\Barryvdh\TranslationManager\Controller@getView'); ?>/' + $(
+                            this).val();
                 } else {
-                    window.location.href = '<?php echo action('\
-                    Barryvdh\ TranslationManager\ Controller @getIndex '); ?>';
+                    window.location.href =
+                        '<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex'); ?>';
                 }
             });
 
@@ -424,7 +421,6 @@
             }
 
         })
-
     </script>
 </head>
 

--- a/__tests__/fixtures/multiline_templating_string_in_script_tag.blade.php
+++ b/__tests__/fixtures/multiline_templating_string_in_script_tag.blade.php
@@ -1,0 +1,14 @@
+@push('scripts')
+<script>
+        const html = `<ul>
+                  <li>Coffee</li>
+                  <li>Tea</li>
+                  <li>Milk</li>
+                  </ul>`;
+
+        const foo = `<ul></ul>`;
+
+        const bar = `<ul>
+  </ul>`;
+    </script>
+@endpush

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1293,7 +1293,6 @@ describe('formatter', () => {
     const expected = [
       `    <script>`,
       `        @isset($data['eval_gestionnaire']->project_perception) @endisset`,
-      ``,
       `    </script>`,
       ``,
     ].join('\n');
@@ -1318,7 +1317,6 @@ describe('formatter', () => {
       '       @foreach ($users as $user)',
       '           let b = 1;',
       '   @endforeach',
-      '',
       '</script>',
     ].join('\n');
 
@@ -1336,7 +1334,6 @@ describe('formatter', () => {
       '    @foreach ($users as $user)',
       '        let b = 1;',
       '    @endforeach',
-      '',
       '</script>',
       ``,
     ].join('\n');
@@ -1354,7 +1351,6 @@ describe('formatter', () => {
     const expected = [
       `<script>`,
       `    @isset($data['eval_gestionnaire']->project_perception) @endisset`,
-      ``,
       `</script>`,
       ``,
     ].join('\n');
@@ -1458,7 +1454,6 @@ describe('formatter', () => {
       `<script type="text/javascript">`,
       `    const errors = @json($errors->all('aaa'));`,
       `    console.log(errors, errors.length);`,
-      ``,
       `</script>`,
       ``,
     ].join('\n');


### PR DESCRIPTION
- fix: 🐛 store script tag in blade template
- fix: 🐛 unexpected new line inserted before script closing tag
- fix: 🐛 wrap line attribute behaviour in script tag
- test: 💍 assert multiline templating string behaviour

<!--- Provide a general summary of your changes in the Title above -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #279

## Description

<!--- Describe your changes in detail -->

- This PR adds behaviour to preserve script tag in blade template

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

- multiline template string in script tag should preserve its white spaces

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- see tests
