### PR TITLE
fix: raw php tag gets unexpected format behaviour

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -593,4 +593,10 @@ describe('The blade formatter CLI', () => {
       await util.checkIfTemplateIsFormattedTwice(input, target);
     },
   );
+
+  test.concurrent('raw php tag should keep indent #304', async () => {
+    const input = 'raw_php_tag.blade.php';
+    const target = 'formatted.raw_php_tag.blade.php';
+    await util.checkIfTemplateIsFormattedTwice(input, target);
+  });
 });

--- a/__tests__/fixtures/formatted.escaped_bug.blade.php
+++ b/__tests__/fixtures/formatted.escaped_bug.blade.php
@@ -1,9 +1,9 @@
 <header class="face <?= isset($face_class) ? $face_class : '' ?>">
-  <div class="container d-flex">
-    @if (isset($face_class) && $face_class === 'face-narrow')
-    <div class="col-md-7 face__wrapper">
-  @else
-      <div class="col-md-6 face__wrapper">
+    <div class="container d-flex">
+        @if (isset($face_class) && $face_class === 'face-narrow')
+            <div class="col-md-7 face__wrapper">
+            @else
+                <div class="col-md-6 face__wrapper">
         @endif
         <h1 class="face__title">{{ $face_title }}</h1>
         @isset($face_subtitle)
@@ -11,42 +11,40 @@
         @endisset
         @isset($face_desc)
             <span class="face__text">{!! $face_desc !!}
-          @endisset
-          @isset($face_desc_mb_hide)
-              <span class="face__text d-none d-lg-inline">&ThinSpace;{!! $face_desc_mb_hide !!}</span>
-          @endisset
+            @endisset
+            @isset($face_desc_mb_hide)
+                <span class="face__text d-none d-lg-inline">&ThinSpace;{!! $face_desc_mb_hide !!}</span>
+            @endisset
         </span>
         @isset($face_btn_text)
             <div class="face__button-box">
-              <a href="{{ $face_anchor or '#request-form' }}" class="btn_regular"
-                onclick="yaCounter.reachGoal('form'); return true;">{{ $face_btn_text }}</a>
-          @endisset
-          @isset($clutch)
-              <script type="text/javascript" src="https://widget.clutch.co/static/js/widget.js">
-              </script>
-              <div class="face__clutch clutch-widget"
-                data-url="https://widget.clutch.co" data-widget-type="2"
-                data-height="50" data-clutchcompany-id="861064"
-                {{ $clutch === 'dark' ? 'data-darkbg="1"' : '' }}>
-              </div>
-          @endisset
-          @isset($face_btn_text)
+                <a href="{{ $face_anchor or '#request-form' }}" class="btn_regular"
+                    onclick="yaCounter.reachGoal('form'); return true;">{{ $face_btn_text }}</a>
+            @endisset
+            @isset($clutch)
+                <script type="text/javascript" src="https://widget.clutch.co/static/js/widget.js">
+                </script>
+                <div class="face__clutch clutch-widget" data-url="https://widget.clutch.co" data-widget-type="2"
+                    data-height="50" data-clutchcompany-id="861064" {{ $clutch === 'dark' ? 'data-darkbg="1"' : '' }}>
+                </div>
+            @endisset
+            @isset($face_btn_text)
             </div>
         @endisset
-      </div>
-      @if (isset($face_class) && $face_class === 'face-wide')
-      <div class="col-md-7 face__image-box">
-    @else
-        <div class="col-md-7 col-lg-6 face__image-box">
-          @endif
-          @isset($face_image)
-              <picture>
-                @isset($face_image_webp)
-                    <source srcset="{{ $face_image_webp }}" type="image/webp">
-                @endisset
-                <img class="face__image" src="{{ $face_image }}" alt="Logo">
-              </picture>
-          @endisset
-        </div>
-      </div>
+    </div>
+    @if (isset($face_class) && $face_class === 'face-wide')
+        <div class="col-md-7 face__image-box">
+        @else
+            <div class="col-md-7 col-lg-6 face__image-box">
+    @endif
+    @isset($face_image)
+        <picture>
+            @isset($face_image_webp)
+                <source srcset="{{ $face_image_webp }}" type="image/webp">
+            @endisset
+            <img class="face__image" src="{{ $face_image }}" alt="Logo">
+        </picture>
+    @endisset
+    </div>
+    </div>
 </header>

--- a/__tests__/fixtures/formatted.raw_php_tag.blade.php
+++ b/__tests__/fixtures/formatted.raw_php_tag.blade.php
@@ -1,0 +1,24 @@
+<section>
+    <div>
+        <div>
+            @if ($foo)
+                <?php echo $user; ?><?php
+                // This is a comment
+                echo 'foobar';
+                ?>
+            @endif
+            @if ($bar)
+                <?php
+                // This is a comment
+                echo json_encode('foobar');
+                ?>
+            @endif
+            @if ($foobar)
+                <?php
+                // This is a comment
+                echo 'foobar';
+                ?><?php echo $user->foo['aaa']; ?>
+            @endif
+        </div>
+    </div>
+</section>

--- a/__tests__/fixtures/formatted_shorttag.blade.php
+++ b/__tests__/fixtures/formatted_shorttag.blade.php
@@ -367,12 +367,9 @@
             $('.group-select').on('change', function() {
                 var group = $(this).val();
                 if (group) {
-                    window.location.href =
-                        '<?php echo action('\Barryvdh\TranslationManager\Controller@getView'); ?>/' + $(
-                            this).val();
+                    window.location.href = '<?php echo action('\Barryvdh\TranslationManager\Controller@getView'); ?>/' + $(this).val();
                 } else {
-                    window.location.href =
-                        '<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex'); ?>';
+                    window.location.href = '<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex'); ?>';
                 }
             });
 
@@ -435,8 +432,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex'); ?>"
-                    class="navbar-brand">
+                <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@getIndex'); ?>" class="navbar-brand">
                     Translation Manager
                 </a>
             </div>
@@ -458,16 +454,14 @@
         <div class="alert alert-success success-publish-all" style="display:none;">
             <p>Done publishing the translations for all group!</p>
         </div>
-        <?php if (Session::has('successPublish')): ?>
+        <?php if(Session::has('successPublish')) : ?>
         <div class="alert alert-info">
             <?php echo Session::get('successPublish'); ?>
         </div>
         <?php endif; ?>
         <p>
-            <?php if (!isset($group)): ?>
-        <form class="form-import" method="POST"
-            action="<?php echo action('\Barryvdh\TranslationManager\Controller@postImport'); ?>"
-            data-remote="true" role="form">
+            <?php if(!isset($group)) : ?>
+        <form class="form-import" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postImport'); ?>" data-remote="true" role="form">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <div class="form-group">
                 <div class="row">
@@ -484,9 +478,7 @@
                 </div>
             </div>
         </form>
-        <form class="form-find" method="POST"
-            action="<?php echo action('\Barryvdh\TranslationManager\Controller@postFind'); ?>"
-            data-remote="true" role="form"
+        <form class="form-find" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postFind'); ?>" data-remote="true" role="form"
             data-confirm="Are you sure you want to scan you app folder? All found translation keys will be added to the database.">
             <div class="form-group">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
@@ -495,41 +487,42 @@
             </div>
         </form>
         <?php endif; ?>
-        <?php if (isset($group)): ?>
-        <form class="form-inline form-publish" method="POST"
-            action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', $group); ?>"
-            data-remote="true" role="form"
+        <?php if(isset($group)) : ?>
+        <form class="form-inline form-publish" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', $group); ?>" data-remote="true"
+            role="form"
             data-confirm="Are you sure you want to publish the translations group '<?php echo $group; ?>? This will overwrite existing language files.">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <button type="submit" class="btn btn-info" data-disable-with="Publishing..">Publish translations</button>
             <a href="<?= action('\Barryvdh\TranslationManager\Controller@getIndex') ?>" class="btn btn-default">Back</a>
-            </form>
+        </form>
         <?php endif; ?>
-    </p>
-    <form role="form" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAddGroup'); ?>">
-        <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-        <div class="form-group">
-            <p>Choose a group to display the group translations. If no groups are visisble, make sure you have run the migrations and imported the translations.</p>
-            <select name="group" id="group" class="form-control group-select">
-                <?php foreach ($groups as $key => $value): ?>
-                    <option value="<?php echo $key; ?>"<?php echo $key == $group ? ' selected' : ''; ?>><?php echo $value; ?></option>
-                <?php endforeach; ?>
-            </select>
-        </div>
-        <div class="form-group">
-            <label>Enter a new group name and start edit translations in that group</label>
-            <input type="text" class="form-control" name="new-group" />
-        </div>
-        <div class="form-group">
-            <input type="submit" class="btn btn-default" name="add-group" value="Add and edit keys" />
-        </div>
-    </form>
-    <?php if ($group): ?>
-        <form action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAdd', [$group]); ?>" method="POST"  role="form">
+        </p>
+        <form role="form" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAddGroup'); ?>">
+            <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+            <div class="form-group">
+                <p>Choose a group to display the group translations. If no groups are visisble, make sure you have run
+                    the migrations and imported the translations.</p>
+                <select name="group" id="group" class="form-control group-select">
+                    <?php foreach($groups as $key => $value): ?>
+                    <option value="<?php echo $key; ?>" <?php echo $key == $group ? ' selected' : ''; ?>><?php echo $value; ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Enter a new group name and start edit translations in that group</label>
+                <input type="text" class="form-control" name="new-group" />
+            </div>
+            <div class="form-group">
+                <input type="submit" class="btn btn-default" name="add-group" value="Add and edit keys" />
+            </div>
+        </form>
+        <?php if($group): ?>
+        <form action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAdd', [$group]); ?>" method="POST" role="form">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <div class="form-group">
                 <label>Add new keys to this group</label>
-                <textarea class="form-control" rows="3" name="keys" placeholder="Add 1 key per line, without the group prefix"></textarea>
+                <textarea class="form-control" rows="3" name="keys"
+                    placeholder="Add 1 key per line, without the group prefix"></textarea>
             </div>
             <div class="form-group">
                 <input type="submit" value="Add keys" class="btn btn-primary">
@@ -540,7 +533,8 @@
                 <span class="btn btn-default enable-auto-translate-group">Use Auto Translate</span>
             </div>
         </div>
-        <form class="form-add-locale autotranslate-block-group hidden" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postTranslateMissing'); ?>">
+        <form class="form-add-locale autotranslate-block-group hidden" method="POST" role="form"
+            action="<?php echo action('\Barryvdh\TranslationManager\Controller@postTranslateMissing'); ?>">
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <div class="row">
                 <div class="col-sm-6">
@@ -548,90 +542,92 @@
                         <label for="base-locale">Base Locale for Auto Translations</label>
                         <select name="base-locale" id="base-locale" class="form-control">
                             <?php foreach ($locales as $locale): ?>
-                                <option value="<?= $locale ?>"><?= $locale ?></option>
+                            <option value="<?= $locale ?>"><?= $locale ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>
                     <div class="form-group">
                         <label for="new-locale">Enter target locale key</label>
-                        <input type="text" name="new-locale" class="form-control" id="new-locale" placeholder="Enter target locale key" />
+                        <input type="text" name="new-locale" class="form-control" id="new-locale"
+                            placeholder="Enter target locale key" />
                     </div>
-                    <?php if (!config('laravel_google_translate.google_translate_api_key')): ?>
-                        <p>
-                            <code>Translating using stichoza/google-translate-php. If you would like to use Google Translate API enter your Google Translate API key to config file laravel_google_translate</code>
-                        </p>
+                    <?php if(!config('laravel_google_translate.google_translate_api_key')): ?>
+                    <p>
+                        <code>Translating using stichoza/google-translate-php. If you would like to use Google Translate
+                            API enter your Google Translate API key to config file laravel_google_translate</code>
+                    </p>
                     <?php endif; ?>
                     <div class="form-group">
                         <input type="hidden" name="with-translations" value="1">
                         <input type="hidden" name="file" value="<?= $group ?>">
-                        <button type="submit" class="btn btn-default btn-block"  data-disable-with="Adding..">Auto translate missing translations</button>
+                        <button type="submit" class="btn btn-default btn-block" data-disable-with="Adding..">Auto
+                            translate missing translations</button>
                     </div>
                 </div>
             </div>
         </form>
         <hr>
-    <h4>Total: <?= $numTranslations ?>, changed: <?= $numChanged ?></h4>
+        <h4>Total: <?= $numTranslations ?>, changed: <?= $numChanged ?></h4>
         <table class="table">
             <thead>
-            <tr>
-                <th width="15%">Key</th>
-                <?php foreach ($locales as $locale): ?>
+                <tr>
+                    <th width="15%">Key</th>
+                    <?php foreach ($locales as $locale): ?>
                     <th><?= $locale ?></th>
-                <?php endforeach; ?>
-                <?php if ($deleteEnabled): ?>
+                    <?php endforeach; ?>
+                    <?php if ($deleteEnabled): ?>
                     <th>&nbsp;</th>
-                <?php endif; ?>
-            </tr>
+                    <?php endif; ?>
+                </tr>
             </thead>
             <tbody>
 
-            <?php foreach ($translations as $key => $translation): ?>
+                <?php foreach ($translations as $key => $translation): ?>
                 <tr id="<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?>">
                     <td><?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?></td>
                     <?php foreach ($locales as $locale): ?>
-                        <?php $t = isset($translation[$locale]) ? $translation[$locale] : null; ?>
+                    <?php $t = isset($translation[$locale]) ? $translation[$locale] : null; ?>
 
-                        <td>
-                            <a href="#edit"
-                               class="editable status-<?php echo $t ? $t->status : 0; ?> locale-<?php echo $locale; ?>"
-                               data-locale="<?php echo $locale; ?>" data-name="<?php echo $locale . '|' . htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?>"
-                               id="username" data-type="textarea" data-pk="<?php echo $t ? $t->id : 0; ?>"
-                               data-url="<?php echo $editUrl; ?>"
-                               data-title="Enter translation"><?php echo $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : ''; ?></a>
-                        </td>
+                    <td>
+                        <a href="#edit" class="editable status-<?php echo $t ? $t->status : 0; ?> locale-<?php echo $locale; ?>"
+                            data-locale="<?php echo $locale; ?>" data-name="<?php echo $locale . '|' . htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?>" id="username"
+                            data-type="textarea" data-pk="<?php echo $t ? $t->id : 0; ?>" data-url="<?php echo $editUrl; ?>"
+                            data-title="Enter translation"><?php echo $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : ''; ?></a>
+                    </td>
                     <?php endforeach; ?>
                     <?php if ($deleteEnabled): ?>
-                        <td>
-                            <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]); ?>"
-                               class="delete-key"
-                               data-confirm="Are you sure you want to delete the translations for '<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?>?"><span
-                                        class="glyphicon glyphicon-trash"></span></a>
-                        </td>
+                    <td>
+                        <a href="<?php echo action('\Barryvdh\TranslationManager\Controller@postDelete', [$group, $key]); ?>" class="delete-key"
+                            data-confirm="Are you sure you want to delete the translations for '<?php echo htmlentities($key, ENT_QUOTES, 'UTF-8', false); ?>?"><span
+                                class="glyphicon glyphicon-trash"></span></a>
+                    </td>
                     <?php endif; ?>
                 </tr>
-            <?php endforeach; ?>
+                <?php endforeach; ?>
             </tbody>
         </table>
-    <?php else: ?>
+        <?php else: ?>
         <fieldset>
             <legend>Supported locales</legend>
             <p>
                 Current supported locales:
             </p>
-            <form  class="form-remove-locale" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postRemoveLocale'); ?>" data-confirm="Are you sure to remove this locale and all of data?">
+            <form class="form-remove-locale" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postRemoveLocale'); ?>"
+                data-confirm="Are you sure to remove this locale and all of data?">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
                 <ul class="list-locales">
-                <?php foreach ($locales as $locale): ?>
+                    <?php foreach($locales as $locale): ?>
                     <li>
                         <div class="form-group">
-                            <button type="submit" name="remove-locale[<?php echo $locale; ?>]" class="btn btn-danger btn-xs" data-disable-with="...">
+                            <button type="submit" name="remove-locale[<?php echo $locale; ?>]"
+                                class="btn btn-danger btn-xs" data-disable-with="...">
                                 &times;
                             </button>
                             <?php echo $locale; ?>
 
                         </div>
                     </li>
-                <?php endforeach; ?>
+                    <?php endforeach; ?>
                 </ul>
             </form>
             <form class="form-add-locale" method="POST" role="form" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postAddLocale'); ?>">
@@ -645,7 +641,8 @@
                             <input type="text" name="new-locale" class="form-control" />
                         </div>
                         <div class="col-sm-2">
-                            <button type="submit" class="btn btn-default btn-block"  data-disable-with="Adding..">Add new locale</button>
+                            <button type="submit" class="btn btn-default btn-block" data-disable-with="Adding..">Add new
+                                locale</button>
                         </div>
                     </div>
                 </div>
@@ -653,14 +650,17 @@
         </fieldset>
         <fieldset>
             <legend>Export all translations</legend>
-            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*'); ?>" data-remote="true" role="form" data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
+            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*'); ?>" data-remote="true"
+                role="form"
+                data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-                <button type="submit" class="btn btn-primary" data-disable-with="Publishing.." >Publish all</button>
+                <button type="submit" class="btn btn-primary" data-disable-with="Publishing..">Publish all</button>
             </form>
         </fieldset>
 
-    <?php endif; ?>
-</div>
+        <?php endif; ?>
+    </div>
 
 </body>
+
 </html>

--- a/__tests__/fixtures/raw_php_tag.blade.php
+++ b/__tests__/fixtures/raw_php_tag.blade.php
@@ -1,0 +1,24 @@
+<section>
+    <div>
+        <div>
+        @if($foo)
+            <?php echo $user ?><?php
+                  // This is a comment
+                  echo 'foobar';
+            ?>
+        @endif
+        @if ($bar)
+            <?php
+                  // This is a comment
+                  echo json_encode("foobar");
+            ?>
+        @endif
+        @if ($foobar)
+            <?php
+                  // This is a comment
+                  echo "foobar";
+                ?><?php echo $user->foo[ "aaa"] ?>
+        @endif
+        </div>
+    </div>
+</section>

--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -480,8 +480,8 @@ describe('formatter', () => {
     const expected = [
       `<?php`,
       `/**`,
-      `* @var \Modules\Common\PageDataBuilderV2\RenderableItems\Card $card`,
-      `*/`,
+      ` * @var \Modules\Common\PageDataBuilderV2\RenderableItems\Card $card`,
+      ` */`,
       `?>`,
       `@extends('layouts.mainLayout')`,
       ``,
@@ -853,7 +853,7 @@ describe('formatter', () => {
     const expected = [
       `<?php`,
       `/* Some comments on this template`,
-      `*/`,
+      ` */`,
       `?>`,
       `<div class="font-ext-links">`,
       `    <a class="btn btn-cta" href="{{ url('download/' . $font->slug) }}" title="Download {{ $font->title }}">`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,6 @@ module.exports = {
   },
   testMatch: ['**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
   testTimeout: 10000,
+  verbose: true,
+  cache: false,
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Shuhei Hayashibara",
   "license": "MIT",
   "dependencies": {
-    "@prettier/plugin-php": "shufo/plugin-php#a18627e03748ee5dd0218b7685a6564672f6c3e7",
+    "@prettier/plugin-php": "0.17.2",
     "php-parser": "3.0.1",
     "aigle": "^1.14.1",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@prettier/plugin-php": "shufo/plugin-php#a18627e03748ee5dd0218b7685a6564672f6c3e7",
-    "php-parser": "shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8",
+    "php-parser": "3.0.1",
     "aigle": "^1.14.1",
     "chalk": "^4.1.0",
     "concat-stream": "^2.0.0",

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -219,7 +219,7 @@ export default class Formatter {
   }
 
   async preserveRawPhpTags(content) {
-    return _.replace(content, /<\?php(.*?)\?>/gms, (match, p1) => {
+    return _.replace(content, /<\?php(.*?)\?>/gms, (match) => {
       return this.storeRawPhpTags(match);
     });
   }

--- a/src/util.js
+++ b/src/util.js
@@ -43,7 +43,7 @@ export function formatStringAsPhp(content) {
     parser: 'php',
     printWidth: 1000,
     singleQuote: true,
-    phpVersion: '7.4',
+    phpVersion: '8.0',
   });
 }
 
@@ -53,7 +53,7 @@ export function formatRawStringAsPhp(content) {
       parser: 'php',
       printWidth: 1000,
       singleQuote: true,
-      phpVersion: '7.4',
+      phpVersion: '8.0',
     })
     .replace(/<\?php echo (.*)?\?>/gs, (match, p1) => {
       return p1.trim().replace(/;\s*$/, '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,7 +1095,7 @@
   dependencies:
     linguist-languages "^7.5.1"
     mem "^8.0.0"
-    php-parser glayzzle/php-parser#da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702
+    php-parser shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -4166,9 +4166,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702:
-  version "3.0.2"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/da4f3f5c9aa2ae6bfa6b001fa185488c20ad1702"
+php-parser@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.1.tgz#69ae957362717cfefbc58eb208d12e48dab2e809"
+  integrity sha512-m6CBPHOoMkzEHoXG0rhEg/VegSNemUNQepHnYtrRgTAh8rsqoO65KqQ32KJ5xe2iplhO0jdwd1UJ9Ea0yHsgYQ==
 
 php-parser@shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,13 +1089,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@prettier/plugin-php@shufo/plugin-php#a18627e03748ee5dd0218b7685a6564672f6c3e7":
-  version "0.16.1"
-  resolved "https://codeload.github.com/shufo/plugin-php/tar.gz/a18627e03748ee5dd0218b7685a6564672f6c3e7"
+"@prettier/plugin-php@0.17.2":
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-php/-/plugin-php-0.17.2.tgz#33f30a640e0c3798c528a7e52b6153ad731c89f3"
+  integrity sha512-0TB3rrQgCELav68Rkk0EPoanJw4tiT879pSsG4AvuvEHtPBSVHgg+lgYSCCOmdfWfTXAa/lvq5c13r0sdt2vUQ==
   dependencies:
     linguist-languages "^7.5.1"
     mem "^8.0.0"
-    php-parser shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8
+    php-parser "https://github.com/glayzzle/php-parser#cca83041d938b972c7ef74648f29de03777b0ea4"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -4171,9 +4172,9 @@ php-parser@3.0.1:
   resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.1.tgz#69ae957362717cfefbc58eb208d12e48dab2e809"
   integrity sha512-m6CBPHOoMkzEHoXG0rhEg/VegSNemUNQepHnYtrRgTAh8rsqoO65KqQ32KJ5xe2iplhO0jdwd1UJ9Ea0yHsgYQ==
 
-php-parser@shufo/php-parser#0b7781fdf88be4b8974320cf27af1588c07e2da8:
+"php-parser@git+https://github.com/glayzzle/php-parser.git#cca83041d938b972c7ef74648f29de03777b0ea4":
   version "3.0.2"
-  resolved "https://codeload.github.com/shufo/php-parser/tar.gz/0b7781fdf88be4b8974320cf27af1588c07e2da8"
+  resolved "git+https://github.com/glayzzle/php-parser.git#cca83041d938b972c7ef74648f29de03777b0ea4"
 
 picomatch@^2.0.4, picomatch@^2.0.5:
   version "2.2.2"


### PR DESCRIPTION
- fix: 🐛 preserve original php tag in template #304
- test: 💍 fix formatted result cause formatter behaviour change
- test: 💍 add test for template including raw php tag
- chore: 🤖 add config for jest

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Multiline raw php tag like

```php
<?php
// foo
echo $user
?>
```

gets unexpected indentation when executing format multiple time.

It should be keep indent level even if it formatted multiple time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #304
