### PR TITLE
fix: disappearing lines with force-expand-multiline

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1493,4 +1493,32 @@ describe('formatter', () => {
       assert.equal(result, expected);
     });
   });
+
+  test('force expand multilines', async () => {
+    const content = [
+      '<div id="username" class="min-h-48 flex flex-col justify-center">',
+      '@if (Auth::check())',
+      '@php($user = Auth::user())',
+      '{{ $user->name }}',
+      '@endif',
+      '</div>',
+    ].join('\n');
+
+    const expected = [
+      '<div',
+      '    id="username"', 
+      '    class="min-h-48 flex flex-col justify-center"',
+      '>',
+      '    @if (Auth::check())',
+      '        @php($user = Auth::user())',
+      '        {{ $user->name }}',
+      '    @endif',
+      '</div>',
+      ``,
+    ].join('\n');
+
+    return new BladeFormatter({wrapAttributes: 'force-expand-multiline'}).format(content).then((result) => {
+      assert.equal(result, expected);
+    });
+  })
 });

--- a/src/util.js
+++ b/src/util.js
@@ -265,14 +265,14 @@ export function revertDirectives(content) {
     .then((res) => {
       return _.replace(
         res,
-        /<beautifyTag.*?start="(.*?)".*?exp=".*?\^\^\^(.*?)\^\^\^.*?">/gs,
+        /<beautifyTag.*?start="(.*?)".*?exp=".*?\^\^\^(.*?)\^\^\^.*?"\s*>/gs,
         (match, p1, p2) => {
           return `${p1}(${p2})`;
         },
       );
     })
     .then((res) => {
-      return _.replace(res, /<\/beautifyTag.*?end="(.*?)">/gs, (match, p1) => {
+      return _.replace(res, /<\/beautifyTag.*?end="(.*?)"\s*>/gs, (match, p1) => {
         return `${p1}`;
       });
     });


### PR DESCRIPTION
## Description
this adds an optional whitespace to the regexes in util.revertDirectives

## Motivation and Context
fixes https://github.com/shufo/blade-formatter/issues/229

## How Has This Been Tested?
a test is included