### PR TITLE
fix: support `@append` directive

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -599,4 +599,10 @@ describe('The blade formatter CLI', () => {
     const target = 'formatted.raw_php_tag.blade.php';
     await util.checkIfTemplateIsFormattedTwice(input, target);
   });
+
+  test.concurrent('raw php tag should keep indent #313', async () => {
+    const input = 'append_tag.blade.php';
+    const target = 'formatted.append_tag.blade.php';
+    await util.checkIfTemplateIsFormattedTwice(input, target);
+  });
 });

--- a/__tests__/fixtures/append_tag.blade.php
+++ b/__tests__/fixtures/append_tag.blade.php
@@ -1,0 +1,11 @@
+<div>
+@section('css')
+    <style>
+        td a {
+
+            text-decoration: underline !important;
+        }
+
+    </style>
+    @append
+    </div>

--- a/__tests__/fixtures/formatted.append_tag.blade.php
+++ b/__tests__/fixtures/formatted.append_tag.blade.php
@@ -1,0 +1,11 @@
+<div>
+    @section('css')
+        <style>
+            td a {
+
+                text-decoration: underline !important;
+            }
+
+        </style>
+    @append
+</div>

--- a/src/indent.js
+++ b/src/indent.js
@@ -61,6 +61,7 @@ export const indentEndTokens = [
   '@endprepend',
   '@endonce',
   '@enderror',
+  '@append',
 ];
 
 export const indentElseTokens = [


### PR DESCRIPTION
- fix: 🐛 add `@append` directive as indent end token
- test: 💍 add test for `@append` directive

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently there is no support for `@append` directive.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: #313

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To support `@append` token.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests.
