### PR TITLE
fix: bug do not indent @section, @push and @prepend if a second argument is present (#318)

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1494,6 +1494,23 @@ describe('formatter', () => {
     });
   });
 
+  test('directives with optional endtags', async () => {
+    const content = [
+      `@if (true)`,
+      `    @push('some-stack', $some->getContent())`,
+      `    @section($aSection, $some->content)`,
+      `    @push('some-stack')`,
+      `        more`,
+      `    @endpush`,
+      `    @prepend($stack->name, 'here we go')`,
+      `@endif`,
+      ``,
+    ].join('\n');
+    return new BladeFormatter().format(content).then((result) => {
+      assert.equal(result, content);
+    });
+  });
+
   test('force expand multilines', async () => {
     const content = [
       '<div id="username" class="min-h-48 flex flex-col justify-center">',

--- a/src/indent.js
+++ b/src/indent.js
@@ -73,6 +73,13 @@ export const indentElseTokens = [
   '@else',
 ];
 
+// Directives which do not need an end token if a parameter is present
+export const optionalStartWithoutEndTokens = {
+  '@section': 2,
+  '@push': 2,
+  '@prepend': 2,
+};
+
 export const tokenForIndentStartOrElseTokens = ['@forelse'];
 
 export const indentStartOrElseTokens = ['@empty'];

--- a/src/util.js
+++ b/src/util.js
@@ -60,6 +60,20 @@ export function formatRawStringAsPhp(content) {
     });
 }
 
+export function getArgumentsCount(expression) {
+  const code = `<?php tmp_func${expression}; ?>`;
+  // eslint-disable-next-line no-underscore-dangle
+  const { ast } = prettier.__debug.parse(code, {
+    parser: 'php',
+    phpVersion: '8.0',
+  });
+  try {
+    return ast.children[0].expression.arguments.length || 0;
+  } catch (e) {
+    return 0;
+  }
+}
+
 export function normalizeIndentLevel(length) {
   if (length < 0) {
     return 0;


### PR DESCRIPTION
do not indent some directives where a second argument makes the endtag needless

## Description
Currently those directives with second argument gets an unexpected indent

## Related Issue
fixes #318

## Motivation and Context
to fix the indents on @section, @push and @prepend with a second parameter

## How Has This Been Tested?
a test is included

---

i tried it first with a custom prettier plugin to get access to the AST, but had problems with it.
hope you are okey to use `prettier.__debug.parse()`