### PR TITLE
chore(doc): change coc extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ new BladeFormatter(options).format(input).then((formatted) => {
 ## Extensions
 
 - [vscode-blade-formatter](https://github.com/shufo/vscode-blade-formatter) - [VSCode](https://code.visualstudio.com/) Extension
-- [coc-blade-formatter](https://github.com/yaegassy/coc-blade-formatter) - [coc.nvim](https://github.com/neoclide/coc.nvim) Extension by [@yaegassy](https://github.com/yaegassy)
+- [coc-blade](https://github.com/yaegassy/coc-blade) - [coc.nvim](https://github.com/neoclide/coc.nvim) Extension by [@yaegassy](https://github.com/yaegassy)
 
 ## Contributing
 


### PR DESCRIPTION
Hi, 

My `coc.nvim` extension that uses `blade-formatter` is now in a separate repository.

I have changed the README. 🙇