### PR TITLE
fix: 🐛 forelse-empty directive in scripts

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -1796,4 +1796,37 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@forelse-@empty-@endforelse directive in scripts', async () => {
+    const content = [
+      `<script>`,
+      `    var addNewCoin = [`,
+      `        @forelse($coins as $coin)`,
+      `            {`,
+      `                 "id": {{$coin->id }},`,
+      `            "name": "{{ $coin->name }}"`,
+      `            },`,
+      `               @empty`,
+      `        @endforelse`,
+      `    ];`,
+      `</script>`,
+    ].join('\n');
+
+    const expected = [
+      `<script>`,
+      `    var addNewCoin = [`,
+      `        @forelse($coins as $coin)`,
+      `            {`,
+      `            "id": {{ $coin->id }},`,
+      `            "name": "{{ $coin->name }}"`,
+      `            },`,
+      `        @empty`,
+      `        @endforelse`,
+      `    ];`,
+      `</script>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -177,7 +177,7 @@ export default class Formatter {
         });
 
         const directives = _.chain(indentStartTokens)
-          .without('@switch', '@forelse')
+          .without('@switch', '@forelse', '@empty')
           .map((x) => _.replace(x, /@/, ''))
           .value();
 


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/251

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Template like below invokes exception because of `@empty` directive

```blade
 <script>
      var addNewCoin = [
               @forelse($coins as $coin)
                   {
                                "id": {{ $coin->id }},
                                "name": "{{ $coin->name }}"
                                },
               @empty
               @endforelse
           ];
            </script>
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/251

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- see tests
