### PR TITLE
fix: 🐛 adds unnecessary space on quoted expression

### DIFF
--- a/__tests__/formatter.test.js
+++ b/__tests__/formatter.test.js
@@ -917,8 +917,8 @@ describe('formatter', () => {
     ].join('\n');
 
     const expected = [
-      `<body class="hold-transition login-page" @if (config('admin.login_background_image'))`,
-      `    style="background: url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;"`,
+      `<body class=\"hold-transition login-page\" @if (config('admin.login_background_image'))style=\"background:`,
+      `    url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;\"`,
       `    @endif>`,
       ``,
     ].join('\n');
@@ -1824,6 +1824,31 @@ describe('formatter', () => {
       `        @endforelse`,
       `    ];`,
       `</script>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('quoted expression should not adds space', async () => {
+    const content = [
+      `@foreach ($items as $item)`,
+      `    @switch($item->status)`,
+      `        @case("status")`,
+      `            // Do something`,
+      `        @break`,
+      `    @endswitch`,
+      `@endforeach`,
+    ].join('\n');
+
+    const expected = [
+      `@foreach ($items as $item)`,
+      `    @switch($item->status)`,
+      `        @case("status")`,
+      `            // Do something`,
+      `        @break`,
+      `    @endswitch`,
+      `@endforeach`,
       ``,
     ].join('\n');
 

--- a/src/util.js
+++ b/src/util.js
@@ -247,7 +247,7 @@ export function preserveDirectives(content) {
         'gis',
       );
       return _.replace(res, regex, (match, p1, p2, p3) => {
-        return `<beautifyTag start="${p1}${p2}" exp="^^^${p3}^^^">`;
+        return `<beautifyTag start="${p1}${p2}" exp="^^^${_.escape(p3)}^^^">`;
       });
     })
     .then((res) => {
@@ -286,7 +286,7 @@ export function revertDirectives(content) {
         res,
         /<beautifyTag.*?start="(.*?)".*?exp=".*?\^\^\^(.*?)\^\^\^.*?"\s*>/gs,
         (match, p1, p2) => {
-          return `${p1}(${p2})`;
+          return `${p1}(${_.unescape(p2)})`;
         },
       );
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

case expression adds unnecessary space if expression is string

```blade
@foreach ($items as $item)
    @switch($item->status)
        @case("status")
            // Do something
        @break
    @endswitch
@endforeach
```

will format into

```blade
@foreach ($items as $item)
    @switch($item->status)
        @case(" status")
            // Do something
        @break
    @endswitch
@endforeach
```

## Related Issue

- fixes: https://github.com/shufo/vscode-blade-formatter/issues/274

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see tests
