### PR TITLE
fix: 🐛 indent error in formatting conditional expression

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1663,18 +1663,9 @@ describe('formatter', () => {
   });
 
   test('conditional expression (while)', async () => {
-    const content = [
-      `@while ($condition< 1)`,
-      `{{-- Do something --}}`,
-      `@endwhile`,
-    ].join('\n');
+    const content = [`@while ($condition< 1)`, `{{-- Do something --}}`, `@endwhile`].join('\n');
 
-    const expected = [
-      `@while ($condition < 1)`,
-      `    {{-- Do something --}}`,
-      `@endwhile`,
-      ``,
-    ].join('\n');
+    const expected = [`@while ($condition < 1)`, `    {{-- Do something --}}`, `@endwhile`, ``].join('\n');
 
     await util.doubleFormatCheck(content, expected);
   });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -809,8 +809,8 @@ describe('formatter', () => {
     ].join('\n');
 
     const expected = [
-      `<body class=\"hold-transition login-page\" @if (config('admin.login_background_image'))style=\"background:`,
-      `    url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;\"`,
+      `<body class=\"hold-transition login-page\" @if (config('admin.login_background_image'))`,
+      `    style=\"background: url({{ config('admin.login_background_image') }}) no-repeat;background-size: cover;\"`,
       `    @endif>`,
       ``,
     ].join('\n');
@@ -1622,7 +1622,7 @@ describe('formatter', () => {
     const expected = [
       `@foreach ($items as $item)`,
       `    @switch($item->status)`,
-      `        @case("status")`,
+      `        @case('status')`,
       `            // Do something`,
       `        @break`,
       `    @endswitch`,

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1632,4 +1632,33 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('conditional expression', async () => {
+    const content = [
+      `@if ($condition < 1)`,
+      `    {{-- Do something --}}`,
+      `@elseif ($condition <2)`,
+      `    {{-- Do something --}}`,
+      `@elseif ($condition< 3)`,
+      `        {{-- Do something --}}`,
+      `@else`,
+      `    {{-- Do something --}}`,
+      `@endif`,
+    ].join('\n');
+
+    const expected = [
+      `@if ($condition < 1)`,
+      `    {{-- Do something --}}`,
+      `@elseif ($condition < 2)`,
+      `    {{-- Do something --}}`,
+      `@elseif ($condition < 3)`,
+      `    {{-- Do something --}}`,
+      `@else`,
+      `    {{-- Do something --}}`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1661,4 +1661,21 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('conditional expression (while)', async () => {
+    const content = [
+      `@while ($condition< 1)`,
+      `{{-- Do something --}}`,
+      `@endwhile`,
+    ].join('\n');
+
+    const expected = [
+      `@while ($condition < 1)`,
+      `    {{-- Do something --}}`,
+      `@endwhile`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -696,14 +696,13 @@ export default class Formatter {
 
   restoreConditions(content: any) {
     return new Promise((resolve) => resolve(content)).then((res: any) =>
-      _.replace(
-        res,
-        new RegExp(`${this.getConditionPlaceholder('(\\d+)')}`, 'gms'),
-        (_match: any, p1: any) => {
-          const matched = this.conditions[p1];
-          return util.formatRawStringAsPhp(matched).trimEnd();
-        },
-      ),
+      _.replace(res, new RegExp(`${this.getConditionPlaceholder('(\\d+)')}`, 'gms'), (_match: any, p1: any) => {
+        const matched = this.conditions[p1];
+        return util
+          .formatRawStringAsPhp(matched)
+          .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+          .trimEnd();
+      }),
     );
   }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -260,13 +260,17 @@ export default class Formatter {
 
   async preserveConditions(content: any) {
     const regex = new RegExp(
-      `(?!\\/\\*.*?\\*\\/)(${conditionalTokens.join(
+      `(${conditionalTokens.join(
         '|',
         // eslint-disable-next-line max-len
-      )})(.*)\\((.*)\\)`,
-      'gim',
+      )})(\\s*?)\\(((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*)\\)`,
+      'gi',
     );
-    return _.replace(content, regex, (match: any, p1: any, p2: any, p3: any) => `${p1}${p2}(${this.storeConditions(p3)})`);
+    return _.replace(
+      content,
+      regex,
+      (match: any, p1: any, p2: any, p3: any) => `${p1}${p2}(${this.storeConditions(p3)})`,
+    );
   }
 
   async preserveRawPhpTags(content: any) {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -21,6 +21,7 @@ import {
   indentStartAndEndTokens,
   inlineFunctionTokens,
   optionalStartWithoutEndTokens,
+  conditionalTokens,
 } from './indent';
 
 export default class Formatter {
@@ -43,6 +44,8 @@ export default class Formatter {
   indentSize: any;
 
   inlineDirectives: any;
+
+  conditions: any;
 
   inlinePhpDirectives: any;
 
@@ -91,6 +94,7 @@ export default class Formatter {
     this.rawBlocks = [];
     this.rawPhpTags = [];
     this.inlineDirectives = [];
+    this.conditions = [];
     this.inlinePhpDirectives = [];
     this.rawPropsBlocks = [];
     this.bladeDirectives = [];
@@ -111,6 +115,7 @@ export default class Formatter {
       .then((formattedAsPhp) => this.preserveBladeComment(formattedAsPhp))
       .then((formattedAsPhp) => this.preserveBladeBrace(formattedAsPhp))
       .then((formattedAsPhp) => this.preserveRawBladeBrace(formattedAsPhp))
+      .then((formattedAsPhp) => this.preserveConditions(formattedAsPhp))
       .then((formattedAsPhp) => this.preserveInlineDirective(formattedAsPhp))
       .then((formattedAsPhp) => this.preserveInlinePhpDirective(formattedAsPhp))
       .then((formattedAsPhp) => this.preserveBladeDirectivesInScripts(formattedAsPhp))
@@ -127,6 +132,7 @@ export default class Formatter {
       .then((formattedAsPhp) => this.restoreBladeDirectivesInScripts(formattedAsPhp))
       .then((formattedAsBlade) => this.restoreInlinePhpDirective(formattedAsBlade))
       .then((formattedAsBlade) => this.restoreInlineDirective(formattedAsBlade))
+      .then((formattedAsBlade) => this.restoreConditions(formattedAsBlade))
       .then((formattedAsBlade) => this.restoreRawBladeBrace(formattedAsBlade))
       .then((formattedAsBlade) => this.restoreBladeBrace(formattedAsBlade))
       .then((formattedAsBlade) => this.restoreBladeComment(formattedAsBlade))
@@ -252,6 +258,17 @@ export default class Formatter {
     return _.replace(content, /\{!!(.*?)!!\}/gs, (_match: any, p1: any) => this.storeRawBladeBrace(p1));
   }
 
+  async preserveConditions(content: any) {
+    const regex = new RegExp(
+      `(?!\\/\\*.*?\\*\\/)(${conditionalTokens.join(
+        '|',
+        // eslint-disable-next-line max-len
+      )})(.*)\\((.*)\\)`,
+      'gim',
+    );
+    return _.replace(content, regex, (match: any, p1: any, p2: any, p3: any) => `${p1}${p2}(${this.storeConditions(p3)})`);
+  }
+
   async preserveRawPhpTags(content: any) {
     return _.replace(content, /<\?php(.*?)\?>/gms, (match: any) => this.storeRawPhpTags(match));
   }
@@ -274,6 +291,10 @@ export default class Formatter {
 
   storeInlineDirective(value: any) {
     return this.getInlinePlaceholder(this.inlineDirectives.push(value) - 1);
+  }
+
+  storeConditions(value: any) {
+    return this.getConditionPlaceholder(this.conditions.push(value) - 1);
   }
 
   storeInlinePhpDirective(value: any) {
@@ -334,6 +355,10 @@ export default class Formatter {
 
   getInlinePlaceholder(replace: any) {
     return _.replace('___inline_directive_#___', '#', replace);
+  }
+
+  getConditionPlaceholder(replace: any) {
+    return _.replace('___directive_condition_#___', '#', replace);
   }
 
   getInlinePhpPlaceholder(replace: any) {
@@ -664,6 +689,19 @@ export default class Formatter {
         (_match: any, p1: any) => {
           const matched = this.inlineDirectives[p1];
           return matched;
+        },
+      ),
+    );
+  }
+
+  restoreConditions(content: any) {
+    return new Promise((resolve) => resolve(content)).then((res: any) =>
+      _.replace(
+        res,
+        new RegExp(`${this.getConditionPlaceholder('(\\d+)')}`, 'gms'),
+        (_match: any, p1: any) => {
+          const matched = this.conditions[p1];
+          return util.formatRawStringAsPhp(matched).trimEnd();
         },
       ),
     );

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -98,6 +98,8 @@ export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endfor', '@endfor
 
 export const inlineFunctionTokens = ['@json'];
 
+export const conditionalTokens = ['@if', '@while', '@case', '@isset', '@empty', '@elseif'];
+
 export function hasStartAndEndToken(tokenizeLineResult: any, originalLine: any) {
   return (
     _.filter(tokenizeLineResult.tokens, (tokenStruct: any) => {


### PR DESCRIPTION
## Description
- fixes: https://github.com/shufo/vscode-blade-formatter/issues/284
- fixes: https://github.com/shufo/vscode-blade-formatter/issues/249

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/284
- https://github.com/shufo/vscode-blade-formatter/issues/249


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- A character like `<` in conditional expression makes unexpected indent error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see added tests