### PR TITLE
feat: 🎸 add ignore statement for disable formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,32 @@ resources/views/products/*
 resources/views/books/**/*
 ```
 
+## Disabling format in file
+
+To disable formatting in your file, you can use blade comments in the following format:
+
+```blade
+{{-- blade-formatter-disable --}}
+    {{ $foo }}
+    {{ $bar }}
+{{-- blade-formatter-enable --}}
+```
+
+To disable format on a specific line, you can use comment in the following format:
+
+```blade
+{{-- blade-formatter-disable-next-line --}}
+    {{ $foo }}
+```
+
+To disable format in an entire file, put a `{{-- blade-formatter-disable --}}` comment at the top of the file:
+
+```blade
+{{-- blade-formatter-disable --}}
+
+{{ $foo }}
+```
+
 ## API
 
 You can use blade formatter by API as well.

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -371,4 +371,10 @@ describe('The blade formatter CLI', () => {
     const target = 'formatted.multiline_blade_brace.blade.php';
     await util.checkIfTemplateIsFormattedTwice(input, target);
   });
+
+  test.concurrent('ignore entire file', async () => {
+    const input = 'ignore_entire_file_comment.blade.php';
+    const target = 'ignore_entire_file_comment.blade.php';
+    await util.checkIfTemplateIsFormattedTwice(input, target);
+  });
 });

--- a/__tests__/fixtures/ignore_entire_file_comment.blade.php
+++ b/__tests__/fixtures/ignore_entire_file_comment.blade.php
@@ -1,0 +1,12 @@
+{{-- blade-formatter-disable --}}
+<div>
+{{-- blade-formatter-disable --}}
+                {{ $foo}}
+{{-- blade-formatter-enable --}}
+@if ($condition < 1)
+    {{-- blade-formatter-disable-next-line --}}
+                {{ $user }}
+@elseif ($condition < 3)
+              {{ $user }}
+@endif
+</div>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1669,4 +1669,104 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('ignore formatting between blade-formatter-disable and blade-formatter-enable', async () => {
+    const content = [
+      `@if ($condition < 1)`,
+      `                {{ $user }}`,
+      `    {{-- blade-formatter-disable --}}`,
+      `                {{ $foo}}`,
+      `    {{-- blade-formatter-enable --}}`,
+      `@elseif (!condition())`,
+      `          {{ $user }}`,
+      `@elseif ($condition < 3)`,
+      `              {{ $user }}`,
+      `    {{-- blade-formatter-disable --}}`,
+      `              {{ $bar}}`,
+      `    {{-- blade-formatter-enable --}}`,
+      `@endif`,
+    ].join('\n');
+
+    const expected = [
+      `@if ($condition < 1)`,
+      `    {{ $user }}`,
+      `    {{-- blade-formatter-disable --}}`,
+      `                {{ $foo}}`,
+      `    {{-- blade-formatter-enable --}}`,
+      `@elseif (!condition())`,
+      `    {{ $user }}`,
+      `@elseif ($condition < 3)`,
+      `    {{ $user }}`,
+      `    {{-- blade-formatter-disable --}}`,
+      `              {{ $bar}}`,
+      `    {{-- blade-formatter-enable --}}`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('ignore formatting after blade-formatter-disable-next-line', async () => {
+    const content = [
+      `<div>`,
+      `@if ($condition < 1)`,
+      `    {{-- blade-formatter-disable-next-line --}}`,
+      `                {{ $user }}`,
+      `@elseif ($condition < 3)`,
+      `              {{ $user }}`,
+      `@endif`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @if ($condition < 1)`,
+      `        {{-- blade-formatter-disable-next-line --}}`,
+      `                {{ $user }}`,
+      `    @elseif ($condition < 3)`,
+      `        {{ $user }}`,
+      `    @endif`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('ignore formatting entire file if blade-formatter-disable on a first line', async () => {
+    const content = [
+      `{{-- blade-formatter-disable --}}`,
+      `<div>`,
+      `{{-- blade-formatter-disable --}}`,
+      `                {{ $foo}}`,
+      `{{-- blade-formatter-enable --}}`,
+      `@if ($condition < 1)`,
+      `    {{-- blade-formatter-disable-next-line --}}`,
+      `                {{ $user }}`,
+      `@elseif ($condition < 3)`,
+      `              {{ $user }}`,
+      `@endif`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    const expected = [
+      `{{-- blade-formatter-disable --}}`,
+      `<div>`,
+      `{{-- blade-formatter-disable --}}`,
+      `                {{ $foo}}`,
+      `{{-- blade-formatter-enable --}}`,
+      `@if ($condition < 1)`,
+      `    {{-- blade-formatter-disable-next-line --}}`,
+      `                {{ $user }}`,
+      `@elseif ($condition < 3)`,
+      `              {{ $user }}`,
+      `@endif`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR adds feature to disable formatting in a file by adding comments.

To disable multiline:

```blade
{{-- blade-formatter-disable --}}
foo
{{-- blade-formatter-enable --}}
```

To disable format on a specific line:

```blade
{{-- blade-formatter-disable-next-line --}}
foo
```

To disable format on an entire file, put `{{-- blade-formatter-disable --}}` on top of the file:

```blade
{{-- blade-formatter-disable --}}

foo
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #395 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Sometimes it is required to ignore specific lines in a file instead of ignore entire file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see tests