### PR TITLE
fix: 🐛 `@{{~}}` syntax occurs parse error

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1769,4 +1769,33 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('double curly brace expression for js framework', async () => {
+    const content = [
+      `<user-listing :data="{{ $data }}" :url="'{{ route('admin.users.index') }}'" v-cloak inline-template>`,
+      `    <tr v-for="item in items" :key="item.id">`,
+      `        <td>@{{ ok? 'YES': 'NO' }}</td>`,
+      `        <td>`,
+      `        @{{ message.split('').reverse().join('') }}`,
+      `        </td>`,
+      `        @{{item.roles.map(role=>role.name).join(', ')}}`,
+      `    </tr>`,
+      `</user-listing>`,
+    ].join('\n');
+
+    const expected = [
+      `<user-listing :data="{{ $data }}" :url="'{{ route('admin.users.index') }}'" v-cloak inline-template>`,
+      `    <tr v-for="item in items" :key="item.id">`,
+      `        <td>@{{ ok ? 'YES' : 'NO' }}</td>`,
+      `        <td>`,
+      `            @{{ message.split('').reverse().join('') }}`,
+      `        </td>`,
+      `        @{{ item.roles.map(role => role.name).join(', ') }}`,
+      `    </tr>`,
+      `</user-listing>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/269

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/269

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support `@{{~}}` syntax.
see: https://laravel.com/docs/5.5/blade#blade-and-javascript-frameworks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests