### PR TITLE
fix:  `@slot` without `@endslot` incorrect formatting

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1798,4 +1798,35 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('slow without endslot directive https://github.com/shufo/vscode-blade-formatter/issues/304', async () => {
+    const content = [
+      `@component('components.article.intro')`,
+      `    @slot('date', $article->formatDate)`,
+      `        @slot('read_mins', $article->readTime)`,
+      `            @if ($author)`,
+      `                @slot('authors', [['link' => $author_link, 'name' => $author]])`,
+      `                @endif`,
+      `                @slot('intro_text')`,
+      `                    {!! $article->introduction !!}`,
+      `                @endslot`,
+      `            @endcomponent`,
+    ].join('\n');
+
+    const expected = [
+      `@component('components.article.intro')`,
+      `    @slot('date', $article->formatDate)`,
+      `    @slot('read_mins', $article->readTime)`,
+      `    @if ($author)`,
+      `        @slot('authors', [['link' => $author_link, 'name' => $author]])`,
+      `    @endif`,
+      `    @slot('intro_text')`,
+      `        {!! $article->introduction !!}`,
+      `    @endslot`,
+      `@endcomponent`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -84,6 +84,7 @@ export const optionalStartWithoutEndTokens = {
   '@section': 2,
   '@push': 2,
   '@prepend': 2,
+  '@slot': 2,
 };
 
 export const tokenForIndentStartOrElseTokens = ['@forelse'];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/304

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/304

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`@slot` directive without `@endslot` directive gets incorrect formatting

e.g.

```blade
    @component('components.article.intro')
        @slot('date', $article->formatDate)
            @slot('read_mins', $article->readTime)
                @if ($author)
                    @slot('authors', [['link' => $author_link, 'name' => $author]])
                    @endif
                    @slot('intro_text')
                        {!! $article->introduction !!}
                    @endslot
                @endcomponent
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests