### PR TITLE
fix: 🐛 format from stdin results always exit code 0

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -190,6 +190,22 @@ describe('The blade formatter CLI', () => {
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
 
+  test.concurrent('error with stdin option', async () => {
+    const cmdResult = await spawnSync(
+      '/bin/cat',
+      ['__tests__/fixtures/syntax.error.blade.php', '|', './bin/blade-formatter', '--stdin'],
+      { stdio: 'pipe', shell: true },
+    );
+
+    // assert exit status is 1
+    expect(cmdResult.status).toEqual(1);
+
+    const cmdOutput = cmdResult.stdout.toString('utf-8');
+
+    expect(cmdOutput).toContain('SyntaxError');
+    expect(cmdOutput).toContain('Parse Error');
+  });
+
   test.concurrent('show not error even if line return exists after unescaped blade brace', async () => {
     const cmdResult = await spawnSync(
       '/bin/cat',

--- a/__tests__/fixtures/syntax.error.blade.php
+++ b/__tests__/fixtures/syntax.error.blade.php
@@ -1,0 +1,32 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+<section id="content">
+    <div class="container mod-users-pd-h">
+        <div class="pf-user-header">
+            <div></div>
+            <p>@lang('users.index')</p>
+        </div>
+        <div class="pf-users-branch">
+            <ul class="pf-users-branch__list">
+                @foreach($tree as $users)
+                <li>
+                    <img src="{{ asset("img/frontend/icon/branch-arrow.svg") }}" alt="branch_arrow">
+                    {{ link_to_route('frontend.users.user.show',$users["name"],$users['_id']) }}
+                </li>
+                @endforeach
+            </ul>
+            <div class="pf-users-branch__btn">
+                @can('create', App\Models\User::class)
+                {!! link_to_route('frontend.users.user.create', __('users.create), [], ['class' => 'btn']) !!}
+                @endcan
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@section('footer')
+@stop

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1846,4 +1846,14 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('formatter throws exception on syntax error', async () => {
+    const content = [
+      `@permission('post.edit')`,
+      `<button class="btn btn-primary" onclick="editPost({{ users('foo) }})">Edit Post</button>`,
+      `@endpermission`,
+    ].join('\n');
+
+    await expect(new BladeFormatter().format(content)).rejects.toThrow('SyntaxError');
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,9 +88,19 @@ export default async function cli() {
 
   if (parsed.argv.stdin) {
     await process.stdin.pipe(
-      concat({ encoding: 'string' }, (text: any) =>
-        new BladeFormatter(parsed.argv).format(text).then((result) => process.stdout.write(result)),
-      ),
+      concat({ encoding: 'string' }, (text: Buffer) => {
+        return new BladeFormatter(parsed.argv)
+          .format(text)
+          .then((result: string | undefined) => {
+            if (result !== undefined) {
+              process.stdout.write(result);
+            }
+          })
+          .catch((error) => {
+            process.stdout.write(`${error.toString()}\n`);
+            process.exit(1);
+          });
+      }),
     );
     return;
   }

--- a/src/errors/formatError.ts
+++ b/src/errors/formatError.ts
@@ -1,0 +1,5 @@
+export default class FormatError extends Error {
+  constructor(message: any) {
+    super(message);
+  }
+}

--- a/src/errors/formatError.ts
+++ b/src/errors/formatError.ts
@@ -1,5 +1,1 @@
-export default class FormatError extends Error {
-  constructor(message: any) {
-    super(message);
-  }
-}
+export default class FormatError extends Error {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import findup from 'findup-sync';
 import Formatter from './formatter';
 import * as util from './util';
 import { findRuntimeConfig, readRuntimeConfig, RuntimeConfig, WrapAttributes } from './runtimeConfig';
+import FormatError from './errors/formatError';
 
 export interface CLIOption {
   write?: boolean;
@@ -68,7 +69,9 @@ class BladeFormatter {
 
   format(content: any, opts = {}) {
     const options = this.options || opts;
-    return new Formatter(options).formatContent(content).catch((err) => console.log(err));
+    return new Formatter(options).formatContent(content).catch((err) => {
+      throw new FormatError(err);
+    });
   }
 
   async formatFromCLI() {


### PR DESCRIPTION
- fix: 🐛 format from stdin results always exit code 0
- test: 💍 add test for error on stdin option
- test: 💍 add test for error throw

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes stdin option behaviour.
Currently formatting with `--stdin` option always returns exit code 0 even if error occurs, but it's unexpected behaviour.
If something occurs while formatting (Syntax Error etc...) it should returns exit code 1.

## How Has This Been Tested?

see tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
