### PR TITLE
fix: 🐛  inline nested parenthesis have unexpected formatting

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1856,4 +1856,35 @@ describe('formatter', () => {
 
     await expect(new BladeFormatter().format(content)).rejects.toThrow('SyntaxError');
   });
+
+  test('inline nested parenthesis #350', async () => {
+    const content = [
+      `@if ($user)`,
+      `    <div>`,
+      `    {{ asset(auth()->user()->getUserMedia('first', 'second')) }}`,
+      `    {{ asset4(asset1(asset2(asset3(auth()->user($aaaa['bbb'])->aaa("aaa"))))) }}`,
+      `    {{ asset(auth()->user($aaaa["bbb"])->aaa('aaa')) }}`,
+      `    {{ $user }}`,
+      `    {{ auth()->user( ["bar","ccc"])->foo("aaa")  }}`,
+      `    {{ asset(auth()->user(['bar', 'ccc'])->tooooooooooooooooooooooooooooooooooolongmethod('aaa')->chained()->tooooooooooooooooooooooooooo()->long()) }}`,
+      `    </div>`,
+      `@endif`,
+    ].join('\n');
+
+    const expected = [
+      `@if ($user)`,
+      `    <div>`,
+      `        {{ asset(auth()->user()->getUserMedia('first', 'second')) }}`,
+      `        {{ asset4(asset1(asset2(asset3(auth()->user($aaaa['bbb'])->aaa('aaa'))))) }}`,
+      `        {{ asset(auth()->user($aaaa['bbb'])->aaa('aaa')) }}`,
+      `        {{ $user }}`,
+      `        {{ auth()->user(['bar', 'ccc'])->foo('aaa') }}`,
+      `        {{ asset(auth()->user(['bar', 'ccc'])->tooooooooooooooooooooooooooooooooooolongmethod('aaa')->chained()->tooooooooooooooooooooooooooo()->long()) }}`,
+      `    </div>`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -706,9 +706,11 @@ export default class Formatter {
 
           if (this.isInline(bladeBrace)) {
             return `${p1}{{ ${util
-              .formatRawStringAsPhp(bladeBrace)
+              .formatRawStringAsPhp(bladeBrace, 120, false)
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-              .trim()
+              .split('\n')
+              .map((line) => line.trim())
+              .join('')
               // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
               .trimRight('\n')} }}`;
           }


### PR DESCRIPTION
- fix: 🐛 inline nested parenthesis have unexpected formatting
- test: 💍 add test for inline nested parenthesis

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes #350 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #350 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Inline nested parenthesis should be keep its form

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
