### PR TITLE
fix: 🐛 hangs when 3 more nested parenthesis used in directive

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1887,4 +1887,37 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('3 more level nested parenthesis #340', async () => {
+    const content = [
+      `<div>`,
+      `    @if (count($foo->bar(Auth::user(), Request::path())) >= 1)`,
+      `    foo`,
+      `    @endif`,
+      `    @if (count($foo->bar(Auth::user($baz->method()), Request::path())) >= 1)`,
+      `    foo`,
+      `    @endif`,
+      `    @foreach (Auth::users($my->users($as->foo)) as $user)`,
+      `    foo`,
+      `    @endif`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @if (count($foo->bar(Auth::user(), Request::path())) >= 1)`,
+      `        foo`,
+      `    @endif`,
+      `    @if (count($foo->bar(Auth::user($baz->method()), Request::path())) >= 1)`,
+      `        foo`,
+      `    @endif`,
+      `    @foreach (Auth::users($my->users($as->foo)) as $user)`,
+      `        foo`,
+      `    @endif`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -222,11 +222,14 @@ export function unindent(directive: any, content: any, level: any, options: any)
   }).join('\n');
 }
 
+// allow up to 4 level nested parenthesis
+const nestedParenthesisRegex = `\\(((?:[^)(]+|\\((?:[^)(]+|\\((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*\\))*\\))*)\\)`;
+
 export function preserveDirectives(content: any) {
   return new Promise((resolve) => resolve(content))
     .then((res: any) => {
       const regex = new RegExp(
-        `(${phpKeywordStartTokens.join('|')})([\\s]*?)\\(((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*)\\)`,
+        `(${phpKeywordStartTokens.join('|')})([\\s]*?)${nestedParenthesisRegex}`,
         'gis',
       );
       return _.replace(
@@ -246,7 +249,7 @@ export function preserveDirectivesInTag(content: any) {
     const regex = new RegExp(
       `(<[^>]*?)(${phpKeywordStartTokens.join(
         '|',
-      )})([\\s]*?)\\(((?:[^)(]+|\\((?:[^)(]+|\\([^)(]*\\))*\\))*)\\)(.*?)(${phpKeywordEndTokens.join('|')})([^>]*?>)`,
+      )})([\\s]*?)${nestedParenthesisRegex}(.*?)(${phpKeywordEndTokens.join('|')})([^>]*?>)`,
       'gis',
     );
     resolve(

--- a/src/util.ts
+++ b/src/util.ts
@@ -228,10 +228,7 @@ const nestedParenthesisRegex = `\\(((?:[^)(]+|\\((?:[^)(]+|\\((?:[^)(]+|\\((?:[^
 export function preserveDirectives(content: any) {
   return new Promise((resolve) => resolve(content))
     .then((res: any) => {
-      const regex = new RegExp(
-        `(${phpKeywordStartTokens.join('|')})([\\s]*?)${nestedParenthesisRegex}`,
-        'gis',
-      );
+      const regex = new RegExp(`(${phpKeywordStartTokens.join('|')})([\\s]*?)${nestedParenthesisRegex}`, 'gis');
       return _.replace(
         res,
         regex,
@@ -247,9 +244,9 @@ export function preserveDirectives(content: any) {
 export function preserveDirectivesInTag(content: any) {
   return new Promise((resolve) => {
     const regex = new RegExp(
-      `(<[^>]*?)(${phpKeywordStartTokens.join(
+      `(<[^>]*?)(${phpKeywordStartTokens.join('|')})([\\s]*?)${nestedParenthesisRegex}(.*?)(${phpKeywordEndTokens.join(
         '|',
-      )})([\\s]*?)${nestedParenthesisRegex}(.*?)(${phpKeywordEndTokens.join('|')})([^>]*?>)`,
+      )})([^>]*?>)`,
       'gis',
     );
     resolve(


### PR DESCRIPTION
✅ Closes: #340

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
see #340

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #340

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Three more nested parenthesis should be allowed in directive expression

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
