### PR TITLE
feat: auto line break around directives

### DIFF
--- a/__tests__/fixtures/formatted.escaped_blade_tag.blade.php
+++ b/__tests__/fixtures/formatted.escaped_blade_tag.blade.php
@@ -1,1 +1,3 @@
-                                    @if ($achievement->user != null) {!! $achievement->user->pay2 !!} 円 @endif
+                                    @if ($achievement->user != null)
+                                        {!! $achievement->user->pay2 !!} 円
+                                    @endif

--- a/__tests__/fixtures/formatted_inline_php_tag.blade.php
+++ b/__tests__/fixtures/formatted_inline_php_tag.blade.php
@@ -1,7 +1,9 @@
 @extends('frontend.layouts.layout')
 @section('head')
 @endsection
-@section('title') commonmanagement @endsection
+@section('title')
+    commonmanagement
+@endsection
 @section('content')
     <div class="multi-column">
         <drawer-nav :items="{{ json_encode($drawerNavigation) }}" csrf-token="{{ csrf_token() }}"></drawer-nav>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -1995,4 +1995,60 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('complex line break', async () => {
+    const content = [
+      `<div>`,
+      `@if ($user) @if ($condition) aaa @endif`,
+      `@endif`,
+      `  @can('edit') bbb`,
+      `  @endcan`,
+      `@auth('user') ccc`,
+      `@endauth`,
+      `</div>`,
+      `<div>`,
+      `@section('title') aaa @endsection`,
+      `</div>`,
+      `<div>@foreach($users as $user) @foreach($shops as $shop) {{ $user["id"] . $shop["id"] }} @endforeach @endforeach</div>`,
+      `<div>@if($users) @foreach($shops as $shop) {{ $user["id"] . $shop["id"] }} @endforeach @endif</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @if ($user)`,
+      `        @if ($condition)`,
+      `            aaa`,
+      `        @endif`,
+      `    @endif`,
+      `    @can('edit')`,
+      `        bbb`,
+      `    @endcan`,
+      `    @auth('user')`,
+      `        ccc`,
+      `    @endauth`,
+      `</div>`,
+      `<div>`,
+      `    @section('title')`,
+      `        aaa`,
+      `    @endsection`,
+      `</div>`,
+      `<div>`,
+      `    @foreach ($users as $user)`,
+      `        @foreach ($shops as $shop)`,
+      `            {{ $user['id'] . $shop['id'] }}`,
+      `        @endforeach`,
+      `    @endforeach`,
+      `</div>`,
+      `<div>`,
+      `    @if ($users)`,
+      `        @foreach ($shops as $shop)`,
+      `            {{ $user['id'] . $shop['id'] }}`,
+      `        @endforeach`,
+      `    @endif`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -471,7 +471,6 @@ describe('formatter', () => {
       `@extends('layouts.mainLayout')`,
       ``,
       `@section('someBlock')`,
-      ``,
       `@endsection`,
       '',
     ].join('\n');
@@ -1074,7 +1073,9 @@ describe('formatter', () => {
 
     const expected = [
       `<div>`,
-      `    @if (count($users) && $users->has('friends')) {{ $user->name }} @endif`,
+      `    @if (count($users) && $users->has('friends'))`,
+      `        {{ $user->name }}`,
+      `    @endif`,
       `</div>`,
       ``,
     ].join('\n');
@@ -1143,13 +1144,15 @@ describe('formatter', () => {
   test('should format blade directive in scripts', async () => {
     const content = [
       `    <script>`,
-      `        @isset($data['eval_gestionnaire']->project_perception) @endisset`,
+      `        @isset($data['eval_gestionnaire']->project_perception) foo @endisset`,
       `    </script>`,
     ].join('\n');
 
     const expected = [
       `    <script>`,
-      `        @isset($data['eval_gestionnaire']->project_perception) @endisset`,
+      `        @isset($data['eval_gestionnaire']->project_perception)`,
+      `            foo`,
+      `        @endisset`,
       `    </script>`,
       ``,
     ].join('\n');
@@ -1201,11 +1204,15 @@ describe('formatter', () => {
   });
 
   test('should format inline directive in scripts #231', async () => {
-    const content = [`<script> @Isset($data['eval_gestionnaire']->project_perception) @endisset </script>`].join('\n');
+    const content = [`<script> @Isset($data['eval_gestionnaire']->project_perception) foo @endisset </script>`].join(
+      '\n',
+    );
 
     const expected = [
       `<script>`,
-      `    @isset($data['eval_gestionnaire']->project_perception) @endisset`,
+      `    @isset($data['eval_gestionnaire']->project_perception)`,
+      `        foo`,
+      `    @endisset`,
       `</script>`,
       ``,
     ].join('\n');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds new behaviour, adds line break before and after directives automatically.

e.g.  complex inlined directive like below

```blade
<div>
@if ($user) @if ($condition) aaa @endif
@endif
  @can('edit') bbb
  @endcan
@auth('user') ccc
@endauth
</div>
<div>@foreach($users as $user) @foreach($shops as $shop) {{ $user["id"] . $shop["id"] }} @endforeach @endforeach</div>
<div>@if($users) @if($shops) @foreach($shops as $shop) {{ $user["id"] . $shop["id"] }} @endforeach @endif @endif</div>
@isset($user) aaa @endisset
```

will format into

```blade
<div>
    @if ($user)
        @if ($condition) aaa @endif
    @endif
    @can('edit')
        bbb
    @endcan
    @auth('user')
        ccc
    @endauth
</div>
<div>
    @foreach ($users as $user)
        @foreach ($shops as $shop)
            {{ $user['id'] . $shop['id'] }}
        @endforeach
    @endforeach
</div>
<div>
    @if ($users)
        @if ($shops)
            @foreach ($shops as $shop)
                {{ $user['id'] . $shop['id'] }}
            @endforeach
        @endif
    @endif
</div>
@isset($user)
    aaa
@endisset
```

## Related issue

- https://github.com/shufo/prettier-plugin-blade/issues/18

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think inline directives should also automatically resolve line breaks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests