### PR TITLE
fix: 🐛 json directive adds unexpected whitespace

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2051,4 +2051,26 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('inline @json directive', async () => {
+    const content = [
+      `<myComponent`,
+      `    :prop-data='@json($data['initialEvents'])'>`,
+      `foo`,
+      `</myComponent>`,
+      `<div data-single-quote='@json('string with single quote')'>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<myComponent :prop-data='@json($data['initialEvents'])'>`,
+      `    foo`,
+      `</myComponent>`,
+      `<div data-single-quote='@json('string with single quote')'>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -224,7 +224,7 @@ export default class Formatter {
     return _.replace(
       content,
       // eslint-disable-next-line max-len
-      /(?!\/\*.*?\*\/)(@php|@class|@button)(\s*?)\(((?:[^)(]+|\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)))*\)/gms,
+      new RegExp(`(?!\\/\\*.*?\\*\\/)(@php|@class|@button|@json)(\\s*?)${nestedParenthesisRegex}`, 'gms'),
       (match: any) => this.storeInlinePhpDirective(match),
     );
   }
@@ -897,7 +897,7 @@ export default class Formatter {
             return formatted;
           }
 
-          return `${p1}${matched}`;
+          return `${p1}${util.formatRawStringAsPhp(matched).trimEnd()}`;
         },
       ),
     );


### PR DESCRIPTION
- fix: 🐛 json directive adds unexpected whitespace
- test: 💍 add test for json directive

## Description
<!--- Describe your changes in detail -->
This PR fixes `@json` directive bug that adds unexpected whitespace if quotation used in `@json` directive is same as outer quotation. 

e.g. 

```blade
<div data-single-quote='@json('string with single quote')'>
</div>
```

will format into

```blade
<div data-single-quote='@json(' string with single quote')'>
</div>
```

fixed behaviour keeps format even if quotation mark is same.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes: https://github.com/shufo/blade-formatter/issues/210
- fixes: https://github.com/shufo/blade-formatter/issues/334

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
