### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ e.g.
 ```json
 {
   "indentSize": 4,
-  "wrapAttributues": "auto",
+  "wrapAttributes": "auto",
   "wrapLineLength": 120,
   "endWithNewLine": true,
   "useTabs": false


### PR DESCRIPTION
Fixed a typo similar to `vscode-blade-formatter`.

- REF
  - <https://github.com/shufo/vscode-blade-formatter/commit/839b4c867f9df3f57cf578025f331d92cc1f9bbf>