### PR TITLE
fix: endforelse causing formatting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,13 @@ $ npm -g config set user root
 <table>
 <tr>
     <td align="center">
+        <a href="https://github.com/dianfishekqi">
+            <img src="https://avatars.githubusercontent.com/u/4225509?v=4" width="100;" alt="dianfishekqi"/>
+            <br />
+            <sub><b>Dian Fishekqi</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/shufo">
             <img src="https://avatars.githubusercontent.com/u/1641039?v=4" width="100;" alt="shufo"/>
             <br />
@@ -342,13 +349,6 @@ $ npm -g config set user root
             <img src="https://avatars.githubusercontent.com/u/47602?v=4" width="100;" alt="schelmo"/>
             <br />
             <sub><b>Schelmo</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/dianfishekqi">
-            <img src="https://avatars.githubusercontent.com/u/4225509?v=4" width="100;" alt="dianfishekqi"/>
-            <br />
-            <sub><b>Dian Fishekqi</b></sub>
         </a>
     </td>
     <td align="center">

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -72,8 +72,8 @@ export const indentEndTokens = [
   '@endwhile',
   '@endauth',
   '@endforelse',
-  '@endfor',
   '@endforeach',
+  '@endfor',
   '@endphp',
   '@endcomponent',
   '@endsection',
@@ -97,7 +97,7 @@ export const indentStartAndEndTokens = ['@default'];
 
 export const phpKeywordStartTokens = ['@forelse', '@if', '@for', '@foreach', '@while', '@sectionmissing', '@case'];
 
-export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endfor', '@endforeach', '@endwhile', '@break'];
+export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endforeach', '@endfor', '@endwhile', '@break'];
 
 export const inlineFunctionTokens = ['@json'];
 


### PR DESCRIPTION
Blade formatter was splitting the `@endforeach` directive into
`
@endfor
each
`

causing a fatal error, It seems like the order of keywords was wrong and @endfor was matching before @endforeach, there might be other directives in the list which suffer from the same problem, maybe a better fix would using a wordmatch, even though reordering the directives fixed the problem in my case.


![image](https://user-images.githubusercontent.com/4225509/154920826-0a09ea7e-891b-4f4e-9fc1-ca8542883691.png)
