### PR TITLE
feat: 🎸 auto line breaking around else/ else if directives

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2333,8 +2333,8 @@ describe('formatter', () => {
       `@if (count($users) === 1)`,
       `    Foo`,
       `@elseif (count($users) > 1)Bar`,
-      `@else`,
-      `    Baz@endif`,
+      `@elseif (count($users) > 2)Bar2`,
+      `@else Baz@endif`,
     ].join('\n');
 
     const expected = [
@@ -2342,6 +2342,8 @@ describe('formatter', () => {
       `    Foo`,
       `@elseif (count($users) > 1)`,
       `    Bar`,
+      `@elseif (count($users) > 2)`,
+      `    Bar2`,
       `@else`,
       `    Baz`,
       `@endif`,

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2335,6 +2335,7 @@ describe('formatter', () => {
       `@elseif (count($users) > 1)Bar`,
       `@elseif (count($users) > 2)Bar2`,
       `@else Baz@endif`,
+      `@can('update') foo @elsecan('read') bar @endcan`,
     ].join('\n');
 
     const expected = [
@@ -2347,6 +2348,11 @@ describe('formatter', () => {
       `@else`,
       `    Baz`,
       `@endif`,
+      `@can('update')`,
+      `    foo`,
+      `@elsecan('read')`,
+      `    bar`,
+      `@endcan`,
       ``,
     ].join('\n');
 

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2327,4 +2327,27 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('else token auto line breaking', async () => {
+    const content = [
+      `@if (count($users) === 1)`,
+      `    Foo`,
+      `@elseif (count($users) > 1)Bar`,
+      `@else`,
+      `    Baz@endif`,
+    ].join('\n');
+
+    const expected = [
+      `@if (count($users) === 1)`,
+      `    Foo`,
+      `@elseif (count($users) > 1)`,
+      `    Bar`,
+      `@else`,
+      `    Baz`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -308,18 +308,16 @@ export default class Formatter {
    * @returns
    */
   breakLineBeforeAndAfterDirective(content: string): string {
-    const unbalancedConditions = ['@case'];
+    const unbalancedConditions = ['@case', ...indentElseTokens];
 
-    _.forEach(unbalancedConditions, (directive) => {
-      // eslint-disable-next-line
-      content = _.replace(
-        content,
-        new RegExp(`(\\s*?)(${directive})(\\s*?)${nestedParenthesisRegex}(\\s*)`, 'gmi'),
-        (match) => {
-          return `\n${match.trim()}\n`;
-        },
-      );
-    });
+    // eslint-disable-next-line
+    content = _.replace(
+      content,
+      new RegExp(`(\\s*?)(${unbalancedConditions.join('|')})(\\s*?)${nestedParenthesisRegex}(\\s*)`, 'gmi'),
+      (match) => {
+        return `\n${match.trim()}\n`;
+      },
+    );
 
     // eslint-disable-next-line
     content = _.replace(content, /@case\S*?\s*?@case/gim, (match) => {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -320,6 +320,15 @@ export default class Formatter {
     );
 
     // eslint-disable-next-line
+    content = _.replace(
+      content,
+      new RegExp(`\\s*?(?!(${_.without(indentElseTokens, '@else').join('|')}))@else\\s+`, 'gim'),
+      (match) => {
+        return `\n${match.trim()}\n`;
+      },
+    );
+
+    // eslint-disable-next-line
     content = _.replace(content, /@case\S*?\s*?@case/gim, (match) => {
       return `${match.replace('\n', '')}`;
     });


### PR DESCRIPTION
- feat: 🎸 auto line breaking around else if directives
- test: 💍 add test for else if line breaking
- fix: 🐛 auto line break around else directive

## Description
This PR adds feature to auto line breaking around else/else if directives.

e.g.

```blade
@if (count($users) === 1)
  Foo
@elseif (count($users) > 1)Bar
@elseif (count($users) > 2) Bar2
@else Baz @endif
```

will format into 

```blade
@if (count($users) === 1)
    Foo
@elseif (count($users) > 1)
    Bar
@elseif (count($users) > 2)
    Bar2
@else
    Baz
@endif
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #474 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Directives like `@else`, `@elseif`, and `@elsecan` should have automatic line breaks as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
