### PR TITLE
fix: line breaking around html tag

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2358,4 +2358,68 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('line breaking with html tag', async () => {
+    const content = [
+      `<div>`,
+      `<div>@can('auth')`,
+      `foo @elsecan('aaa') bar @endcan</div>`,
+      `<div>@foreach($users as $user)`,
+      `{{$user}} bar @endforeach</div></div>`,
+      `<p class="@if($verified) mb-6 @endif">@if($user)`,
+      `{!!$user!!} @elseif ($authorized) foo @else bar @endif</p>`,
+      `<input type="text" />`,
+      `<p>@for ($i = 0; $i < 5; $i++)`,
+      `aaa`,
+      `@endfor</p>`,
+      `<p>@if($user)`,
+      `{!!$user!!} @elseif ($authorized) foo @else bar @endif`,
+      ``,
+      `</p>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    <div>`,
+      `        @can('auth')`,
+      `            foo`,
+      `        @elsecan('aaa')`,
+      `            bar`,
+      `        @endcan`,
+      `    </div>`,
+      `    <div>`,
+      `        @foreach ($users as $user)`,
+      `            {{ $user }} bar`,
+      `        @endforeach`,
+      `    </div>`,
+      `</div>`,
+      `<p class="@if ($verified) mb-6 @endif">`,
+      `    @if ($user)`,
+      `        {!! $user !!}`,
+      `    @elseif ($authorized)`,
+      `        foo`,
+      `    @else`,
+      `        bar`,
+      `    @endif`,
+      `</p>`,
+      `<input type="text" />`,
+      `<p>`,
+      `    @for ($i = 0; $i < 5; $i++)`,
+      `        aaa`,
+      `    @endfor`,
+      `</p>`,
+      `<p>`,
+      `    @if ($user)`,
+      `        {!! $user !!}`,
+      `    @elseif ($authorized)`,
+      `        foo`,
+      `    @else`,
+      `        bar`,
+      `    @endif`,
+      `</p>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -338,6 +338,7 @@ export default class Formatter {
       new RegExp(`(\\s*?)(${unbalancedConditions.join('|')})(\\s*?)${nestedParenthesisRegex}(\\s*)`, 'gmi'),
       (match) => {
         return `\n${match.trim()}\n`;
+        // handle else directive
       },
     );
 
@@ -347,11 +348,13 @@ export default class Formatter {
       new RegExp(`\\s*?(?!(${_.without(indentElseTokens, '@else').join('|')}))@else\\s+`, 'gim'),
       (match) => {
         return `\n${match.trim()}\n`;
+        // handle case directive
       },
     );
 
     // eslint-disable-next-line
     content = _.replace(content, /@case\S*?\s*?@case/gim, (match) => {
+      // handle unbalanced echos
       return `${match.replace('\n', '')}`;
     });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -308,6 +308,28 @@ export default class Formatter {
    * @returns
    */
   breakLineBeforeAndAfterDirective(content: string): string {
+    // handle directive around html tags
+    // eslint-disable-next-line
+    content = _.replace(
+      content,
+      new RegExp(
+        `(?<=<.*?>)(${_.without(indentStartTokens, '@php').join('|')})(\\s*)${nestedParenthesisRegex}.*?(?=<.*?>)`,
+        'gmis',
+      ),
+      (match) => {
+        return `\n${match.trim()}\n`;
+      },
+    );
+
+    // eslint-disable-next-line
+    content = _.replace(
+      content,
+      new RegExp(`(?<=<.*?>).*?(${_.without(indentEndTokens, '@endphp').join('|')})(?=<.*?>)`, 'gmis'),
+      (match) => {
+        return `\n${match.trim()}\n`;
+      },
+    );
+
     const unbalancedConditions = ['@case', ...indentElseTokens];
 
     // eslint-disable-next-line


### PR DESCRIPTION
- fix: 🐛 line break does not occur around html tag
- refactor: 💡 add description comment
- test: 💍 add test for line breaking with html tag

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds behaviour to breaking lines around html tag.

e.g.

```blade
<div>
<div>@can('auth')
foo @elsecan('aaa') bar @endcan</div>
<div>@foreach($users as $user)
{{$user}} bar @endforeach</div></div>
<div>@if (count($users) === 1) Foo @elseif (count($users) > 1)Bar @elseif (count($users) > 2) Bar2 @else Baz @endif</div>
```

will format into

```blade
<div>
    <div>
        @can('auth')
            foo
        @elsecan('aaa')
            bar
        @endcan
    </div>
    <div>
        @foreach ($users as $user)
            {{ $user }} bar
        @endforeach
    </div>
</div>
<div>
    @if (count($users) === 1)
        Foo
    @elseif (count($users) > 1)
        Bar
    @elseif (count($users) > 2)
        Bar2
    @else
        Baz
    @endif
</div>
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #483

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Directives enclosed in html tags should automatically include line breaks, just like normal directives.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
