### PR TITLE
fix: 🐛 inlined php doc gets unexpected line break

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2422,4 +2422,25 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('raw php inlined comment #493', async () => {
+    const content = [
+      `<?php /** foo */ echo 1; ?>`,
+      `<?php /** @var \App\Models\Game $game */ ?>`,
+      `@foreach ($preview['new'] as $game)`,
+      `    <x-game.preview.new :game="$game" />`,
+      `@endforeach`,
+    ].join('\n');
+
+    const expected = [
+      `<?php /** foo */ echo 1; ?>`,
+      `<?php /** @var \App\Models\Game $game */ ?>`,
+      `@foreach ($preview['new'] as $game)`,
+      `    <x-game.preview.new :game="$game" />`,
+      `@endforeach`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1003,6 +1003,14 @@ export default class Formatter {
         (_match: any, p1: any) => {
           // const result= this.rawPhpTags[p1];
           try {
+            const matched = this.rawPhpTags[p1];
+            const commentBlockExists = /(?<=<\?php\s*?)\/\*.*?\*\/(?=\s*?\?>)/gim.test(matched);
+            const inlinedComment = commentBlockExists && this.isInline(matched);
+
+            if (inlinedComment) {
+              return matched;
+            }
+
             const result = util
               .formatStringAsPhp(this.rawPhpTags[p1])
               .trim()


### PR DESCRIPTION
- fix: 🐛 inlined php doc gets unexpected line break
- test: 💍 add test for inlined php doc

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the behaviour that inlined php doc gets expected line break

e.g. 

```blade
<?php /** @var \App\Models\Game $game */ ?>
```

will format into

```blade
<?php /** @var \App\Models\Game $game */ 
?>
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes: #493

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests