### PR TITLE
fix: 🐛 include directive does not indent parameters

### DIFF
--- a/__tests__/fixtures/formatted.blade_brace_without_space.blade.php
+++ b/__tests__/fixtures/formatted.blade_brace_without_space.blade.php
@@ -29,7 +29,9 @@
                 @if (0 < count($errors))
                     <div class="alert alert-danger" role="alert">error</div>
                 @endif
-                @include("users.{$directory}.create_and_edits_form", ['_botton_text' => $_botton_text])
+                @include("users.{$directory}.create_and_edits_form", [
+                    '_botton_text' => $_botton_text,
+                ])
             </div>
         </div>
     </div>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2496,4 +2496,63 @@ describe('formatter', () => {
     const result2 = await new Formatter({ sortTailwindcssClasses: true }).formatContent(result);
     assert.equal(result2, result);
   });
+
+  test('@include directive should format its parameter', async () => {
+    const content = [
+      `@include('parts.partials.buttons.btn-group', ["buttons" => [`,
+      `[`,
+      `"style" => "link",`,
+      `"link" => [`,
+      `"title" => "Call to Action",`,
+      `"url" => "#",`,
+      `"target" => "_self",`,
+      `],`,
+      `],`,
+      `]])`,
+      `<div>`,
+      `@include('parts.partials.buttons.btn-group', ["buttons" => [`,
+      `[`,
+      `"style" => "link",`,
+      `"link" => [`,
+      `"title" => "Call to Action",`,
+      `"url" => "#",`,
+      `"target" => "_self",`,
+      `],`,
+      `],`,
+      `]])`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `@include('parts.partials.buttons.btn-group', [`,
+      `    'buttons' => [`,
+      `        [`,
+      `            'style' => 'link',`,
+      `            'link' => [`,
+      `                'title' => 'Call to Action',`,
+      `                'url' => '#',`,
+      `                'target' => '_self',`,
+      `            ],`,
+      `        ],`,
+      `    ],`,
+      `])`,
+      `<div>`,
+      `    @include('parts.partials.buttons.btn-group', [`,
+      `        'buttons' => [`,
+      `            [`,
+      `                'style' => 'link',`,
+      `                'link' => [`,
+      `                    'title' => 'Call to Action',`,
+      `                    'url' => '#',`,
+      `                    'target' => '_self',`,
+      `                ],`,
+      `            ],`,
+      `        ],`,
+      `    ])`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -256,7 +256,7 @@ export default class Formatter {
     return _.replace(
       content,
       // eslint-disable-next-line max-len
-      new RegExp(`(?!\\/\\*.*?\\*\\/)(@php|@class|@button|@json)(\\s*?)${nestedParenthesisRegex}`, 'gms'),
+      new RegExp(`(?!\\/\\*.*?\\*\\/)(@php|@class|@button|@json|@include)(\\s*?)${nestedParenthesisRegex}`, 'gms'),
       (match: any) => this.storeInlinePhpDirective(match),
     );
   }
@@ -963,29 +963,10 @@ export default class Formatter {
               .trimRight('\n')}`;
           }
 
-          if (matched.includes('@button')) {
-            const formatted = _.replace(matched, /@(button)(.*)/gis, (match2: any, p3: any, p4: any) => {
+          if (/(@button|@class|@include)/gi.test(matched)) {
+            const formatted = _.replace(matched, /@(button|class|include)(.*)/gis, (match2: any, p3: any, p4: any) => {
               const inside = util
                 .formatRawStringAsPhp(`func_inline_for_${p3}${p4}`, 80, true)
-                .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-                .trim()
-                // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
-                .trimRight('\n');
-
-              if (this.isInline(inside)) {
-                return `${this.indentRawPhpBlock(p1, `@${inside}`.replace('func_inline_for_', ''))}`;
-              }
-
-              return `${p1}${this.indentRawPhpBlock(p1, `@${inside}`.replace('func_inline_for_', ''))}`;
-            });
-
-            return formatted;
-          }
-
-          if (matched.includes('@class')) {
-            const formatted = _.replace(matched, /@(class)(.*)/gis, (match2: any, p4: any, p5: any) => {
-              const inside = util
-                .formatRawStringAsPhp(`func_inline_for_${p4}${p5}`, 80, true)
                 .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
                 .trim()
                 // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes indentation behaviour that include directive does not indent parameters

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes: #501 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- see #501 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
