### PR TITLE
fix: 🐛 formatted include directive adds unnecessary comma

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2555,4 +2555,18 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@include directive should not add an extra comma on long view name #504', async () => {
+    const content = [`@include('livewire.cx.equipment-list-internal.account', ['account' => $account])`].join('\n');
+
+    const expected = [
+      `@include(`,
+      `    'livewire.cx.equipment-list-internal.account',`,
+      `    ['account' => $account]`,
+      `)`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -968,6 +968,7 @@ export default class Formatter {
               const inside = util
                 .formatRawStringAsPhp(`func_inline_for_${p3}${p4}`, 80, true)
                 .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+                .replace(/,(\s*?\))/gis, (_match5, p5) => p5)
                 .trim()
                 // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
                 .trimRight('\n');


### PR DESCRIPTION
✅ Closes: #504

## Description
<!--- Describe your changes in detail -->
This PR fixes `@include` directive behaviour that include directive with long view name adds unnecessary comma causing syntax error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes #504 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests