### PR TITLE
fix: 🐛 inilne script tag removes previous DOM

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2617,4 +2617,20 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('inline script tag should keep its element #508', async () => {
+    const content = [`<p>foo</p><p>bar</p><script>document.write("buz");</script><p>blah</p>`].join('\n');
+
+    const expected = [
+      `<p>foo</p>`,
+      `<p>bar</p>`,
+      `<script>`,
+      `    document.write("buz");`,
+      `</script>`,
+      `<p>blah</p>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -613,7 +613,7 @@ export default class Formatter {
   }
 
   getScriptPlaceholder(replace: any) {
-    return _.replace('___scripts_#___', '#', replace);
+    return _.replace('<preservedScript ___scripts_#___ />', '#', replace);
   }
 
   getClassPlaceholder(replace: any, length: any) {
@@ -783,6 +783,10 @@ export default class Formatter {
 
     const indented = _.chain(lines)
       .map((line: any, index: any) => {
+        if (index === 0) {
+          return line;
+        }
+
         if (index === lines.length - 1) {
           return prefixForEnd + line;
         }
@@ -796,7 +800,7 @@ export default class Formatter {
       .value()
       .join('\n');
 
-    return this.restoreTemplatingString(indented);
+    return this.restoreTemplatingString(`${prefix}${indented}`);
   }
 
   indentRawPhpBlock(prefix: any, content: any) {


### PR DESCRIPTION
✅ Closes: #508

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #508 that inline script tag with DOM element removes its previous element.

```blade
<p>foo</p><p>bar</p><script>document.write("buz");</script><p>blah</p>
```

will format into

```blade
    <p>foo</p>
    <script>
        document.write("buz");
    </script><p>blah</p>
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: #508

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

inline script tag with DOM element should keep its content

## How Has This Been Tested?

see tests
