### PR TITLE
feat: add support for selected, disabled and checked directive

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2633,4 +2633,21 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('inline @php directive in script tag', async () => {
+    const content = [
+      `<script>`,
+      `@php(     $password_reset_url=View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset', env('test', env('test'))))`,
+      `</script>`,
+    ].join('\n');
+
+    const expected = [
+      `<script>`,
+      `    @php($password_reset_url = View::getSection('password_reset_url') ?? config('adminlte.password_reset_url', 'password/reset', env('test', env('test'))))`,
+      `</script>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2651,3 +2651,51 @@ describe('formatter', () => {
     await util.doubleFormatCheck(content, expected);
   });
 });
+test('@checked directive', async () => {
+  const content = [
+    `<input type="checkbox"`,
+    `        name="active"`,
+    `        value="active"`,
+    `        @checked(old('active',$user->active)) />`,
+  ].join('\n');
+
+  const expected = [
+    `<input type="checkbox" name="active" value="active" @checked(old('active', $user->active)) />`,
+    ``,
+  ].join('\n');
+
+  await util.doubleFormatCheck(content, expected);
+});
+
+test('@selected directive', async () => {
+  const content = [
+    `<select name="version">`,
+    `@foreach ($product->versions as $version)`,
+    `<option value="{{ $version }}" @selected(old('version')==$version)>`,
+    `{{ $version }}`,
+    `</option>`,
+    `@endforeach`,
+    `</select>`,
+  ].join('\n');
+
+  const expected = [
+    `<select name="version">`,
+    `    @foreach ($product->versions as $version)`,
+    `        <option value="{{ $version }}" @selected(old('version') == $version)>`,
+    `            {{ $version }}`,
+    `        </option>`,
+    `    @endforeach`,
+    `</select>`,
+    ``,
+  ].join('\n');
+
+  await util.doubleFormatCheck(content, expected);
+});
+
+test('@disabled directive', async () => {
+  const content = [`<button type="submit" @disabled($errors->isNotEmpty() )>Submit</button>`].join('\n');
+
+  const expected = [`<button type="submit" @disabled($errors->isNotEmpty())>Submit</button>`, ``].join('\n');
+
+  await util.doubleFormatCheck(content, expected);
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -256,7 +256,7 @@ export default class Formatter {
     return _.replace(
       content,
       // eslint-disable-next-line max-len
-      new RegExp(`(?!\\/\\*.*?\\*\\/)(@php|@class|@button|@json|@include)(\\s*?)${nestedParenthesisRegex}`, 'gms'),
+      new RegExp(`(?!\\/\\*.*?\\*\\/)(${inlineFunctionTokens.join('|')})(\\s*?)${nestedParenthesisRegex}`, 'gms'),
       (match: any) => this.storeInlinePhpDirective(match),
     );
   }

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -99,7 +99,16 @@ export const phpKeywordStartTokens = ['@forelse', '@if', '@for', '@foreach', '@w
 
 export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endforeach', '@endfor', '@endwhile', '@break'];
 
-export const inlineFunctionTokens = ['@json'];
+export const inlineFunctionTokens = [
+  '@json',
+  '@selected',
+  '@checked',
+  '@disabled',
+  '@php',
+  '@include',
+  '@button',
+  '@class',
+];
 
 export const conditionalTokens = ['@if', '@while', '@case', '@isset', '@empty', '@elseif'];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for `@selected`, `@disabled` and `@checked` directive

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Laravel 9 added new directive `@selected`, `@disabled` and `@checked` 
https://laravel.com/docs/9.x/blade#checked-and-selected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests