### PR TITLE
fix: curly braces with long expression gets unexpected result

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2756,4 +2756,33 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('long expression blade brace', async () => {
+    const content = [
+      `<a href="{{ $relatedAuthority->id }}" class="no-border"`,
+      `   itemprop="{{ $author->isCorporateBody() ?`,
+      `                ($relatedAuthority->isCorporateBody() ? 'knowsAbout' : 'member') :`,
+      `                ($relatedAuthority->isCorporateBody() ? 'memberOf' : 'knows') }}">`,
+      `    <strong>{{ formatName($relatedAuthority->name) }}</strong>`,
+      `    <i class="icon-arrow-right"></i>`,
+      `</a><br>`,
+    ].join('\n');
+
+    const expected = [
+      `<a href="{{ $relatedAuthority->id }}" class="no-border"`,
+      `    itemprop="{{ $author->isCorporateBody()`,
+      `        ? ($relatedAuthority->isCorporateBody()`,
+      `            ? 'knowsAbout'`,
+      `            : 'member')`,
+      `        : ($relatedAuthority->isCorporateBody()`,
+      `            ? 'memberOf'`,
+      `            : 'knows') }}">`,
+      `    <strong>{{ formatName($relatedAuthority->name) }}</strong>`,
+      `    <i class="icon-arrow-right"></i>`,
+      `</a><br>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -808,8 +808,12 @@ export default class Formatter {
       return content;
     }
 
-    if (this.isInline(content)) {
+    if (this.isInline(content) && /\s/.test(prefix)) {
       return `${prefix}${content}`;
+    }
+
+    if (this.isInline(content) && /\S/.test(prefix)) {
+      return `${content}`;
     }
 
     const leftIndentAmount = detectIndent(prefix).amount;
@@ -888,7 +892,7 @@ export default class Formatter {
           return `${p1}{{ ${this.indentRawPhpBlock(
             p1,
             util
-              .formatRawStringAsPhp(bladeBrace)
+              .formatRawStringAsPhp(bladeBrace, 120, true)
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
               .trim()
               // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.


### PR DESCRIPTION
- fix: 🐛 curly braces with long expression gets unexpected result
- test: 💍 add test for curly braces with long expression

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes the behavior that caused unexpected results for braces in certain conditions.
Currently, unexpected formatting happens when curly braces containing long expressions.


e.g.

```blade
    <a href="{{ $relatedAuthority->id }}" class="no-border"
       itemprop="{{ $author->isCorporateBody() ?
                    ($relatedAuthority->isCorporateBody() ? 'knowsAbout' : 'member') :
                    ($relatedAuthority->isCorporateBody() ? 'memberOf' : 'knows') }}">
        <strong>{{ formatName($relatedAuthority->name) }}</strong>
        <i class="icon-arrow-right"></i>
    </a><br>
```

will format into

```blade
    <a href="{{ $relatedAuthority->id }}"
        class="no-border"
        itemprop="{{                                                         itemprop="$author->isCorporateBody() ? ($relatedAuthority->isCorporateBody() ? 'knowsAbout' : 'member') : ($relatedAuthority->isCorporateBody() ? 'memberOf' : 'knows') }}">
        <strong>{{ formatName($relatedAuthority->name) }}</strong>
        <i class="icon-arrow-right"></i>
    </a><br>

```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
