### PR TITLE
fix: 🐛 whitespace sensitive tag gets formatted unexpectedly

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2785,4 +2785,45 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('whitespace sensitive tag should keep its content unformatted', async () => {
+    const content = [
+      `<div>`,
+      `@foreach (config('translatable.locales') as $i => $locale)`,
+      `    <div role="tabpanel" class="tab-pane  {{ $i == 0 ? 'active' : '' }}" id="{{ $locale }}">`,
+      `        <div class="form-group">`,
+      `            <textarea class="form-control wysiwyg" name="{{ $locale }}[content]" rows="8" id="{{ $locale }}[content]"`,
+      ` cols="8">`,
+      `    {{ old($locale . '[content]', $notice->translateOrNew($locale)->content) }} </textarea>`,
+      `        </div>`,
+      `    </div>`,
+      `@endforeach`,
+      `    </div>`,
+      `<div>`,
+      `<pre>`,
+      `aaaa </pre>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @foreach (config('translatable.locales') as $i => $locale)`,
+      `        <div role="tabpanel" class="tab-pane  {{ $i == 0 ? 'active' : '' }}" id="{{ $locale }}">`,
+      `            <div class="form-group">`,
+      `                <textarea class="form-control wysiwyg" name="{{ $locale }}[content]" rows="8" id="{{ $locale }}[content]"`,
+      `                    cols="8">`,
+      `    {{ old($locale . '[content]', $notice->translateOrNew($locale)->content) }} </textarea>`,
+      `            </div>`,
+      `        </div>`,
+      `    @endforeach`,
+      `</div>`,
+      `<div>`,
+      `    <pre>`,
+      `aaaa </pre>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes the behaviour that whitespace sensitive tags (like `textarea`, `pre`) gets unexpectedly formatted.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: https://github.com/shufo/vscode-blade-formatter/issues/357

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Tags like `textarea`, `pre` should keep its content unformatted.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
