### PR TITLE
fix: 🐛 some character prevent reordering of tailwindcss classes

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2460,6 +2460,15 @@ describe('formatter', () => {
     });
   });
 
+  test('sort tailwindcss classs with various character', function () {
+    const content = [`<div class="m-5 md:tw-mx-[1rem]   tw-mx-1 foo"></div>`].join('\n');
+    const expected = [`<div class="md:tw-mx-[1rem] tw-mx-1 foo m-5"></div>`, ``].join('\n');
+
+    return new Formatter({ sortTailwindcssClasses: true }).formatContent(content).then((result: string) => {
+      assert.equal(result, expected);
+    });
+  });
+
   test('long tailwindcss classs', async () => {
     const content = [
       `<div class="container z-50                                                      z-10 z-20 justify-center text-left foo md:text-center">`,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -183,7 +183,7 @@ export default class Formatter {
       return content;
     }
 
-    return _.replace(content, /\bclass\s*=\s*([\"\'])([_a-zA-Z0-9\s\-\:\/]+)([\"\'])/gi, (_match, p1, p2, p3) => {
+    return _.replace(content, /\bclass\s*=\s*([\"\'])(.+?)([\"\'])/gis, (_match, p1, p2, p3) => {
       return `class=${p1}${sortClasses(p2)}${p3}`;
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes behavior of characters preventing tailwindcss class reordering.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: https://github.com/shufo/prettier-plugin-blade/issues/33

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Any character should be able to reordering tailwindcss classes

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
