### PR TITLE
fix: 🐛 class sorting fails when blade braces mixed in classes

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2835,4 +2835,21 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('sort blade brace mixes classes', async () => {
+    const content = [
+      `<div`,
+      `    class="px-4 py-5 bg-white sm:p-6 shadow     {{ isset($actions) ? 'sm:rounded-tl-md sm:rounded-tr-md' : 'sm:rounded-md' }} {{ isset($actions) ? 'foo' : 'bar' }}">`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div`,
+      `    class="{{ isset($actions) ? 'sm:rounded-tl-md sm:rounded-tr-md' : 'sm:rounded-md' }} {{ isset($actions) ? 'foo' : 'bar' }} bg-white px-4 py-5 shadow sm:p-6">`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheckWithSort(content, expected, { sortTailwindcssClasses: true });
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2850,6 +2850,6 @@ describe('formatter', () => {
       ``,
     ].join('\n');
 
-    await util.doubleFormatCheckWithSort(content, expected, { sortTailwindcssClasses: true });
+    await util.doubleFormatCheck(content, expected, { sortTailwindcssClasses: true });
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -122,7 +122,6 @@ export default class Formatter {
 
   formatContent(content: any) {
     return new Promise((resolve) => resolve(content))
-      .then((target) => this.sortTailwindcssClasses(target))
       .then((target) => this.preserveIgnoredLines(target))
       .then((target) => this.preserveCurlyBraceForJS(target))
       .then((target) => this.preserveRawPhpTags(target))
@@ -140,6 +139,7 @@ export default class Formatter {
         return target;
       })
       .then((target) => this.preserveScripts(target))
+      .then((target) => this.sortTailwindcssClasses(target))
       .then((target) => this.preserveClass(target))
       .then((target) => this.preserveHtmlTags(target))
       .then((target) => this.formatAsHtml(target))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes the behaviour that class sorting fails when blade braces are mixed in classes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

none

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should be sortable even if blade braces are mixes in classes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
