### PR TITLE
fix: multiline blade component attribute indents forever

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -474,4 +474,10 @@ describe('The blade formatter CLI', () => {
     expect(cmdResult).toContain('Config Error');
     expect(cmdResult).toContain('must be integer');
   });
+
+  test.concurrent('component attribute', async () => {
+    const input = 'component_attribute.blade.php';
+    const target = 'formatted.component_attribute.blade.php';
+    await util.checkIfTemplateIsFormattedTwice(input, target);
+  });
 });

--- a/__tests__/fixtures/component_attribute.blade.php
+++ b/__tests__/fixtures/component_attribute.blade.php
@@ -5,6 +5,7 @@
 'series' => ['label' => 'Recurring meeting'],
 'scheduler'=>[ 'label' => 'Find a meeting date']]" />
 <x-h1 :variable123-with-hyphen=" ['array'=>123]"/>
+<x-h1 legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type" :variable123-with-hyphen=" ['array'=>123,'series' => ['label' => 'Recurring meeting'],'series2' => ['label' => 'Recurring meeting'], 'series3' => ['label' => 'Recurring meeting']]"/>
 <div>
 <x-h1 :variable1=" [
 'key1'=>123,

--- a/__tests__/fixtures/component_attribute.blade.php
+++ b/__tests__/fixtures/component_attribute.blade.php
@@ -1,0 +1,82 @@
+@section('body')
+    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"
+:inline=" true   " :options="[
+'single'=> ['label' => 'Default'],
+'series' => ['label' => 'Recurring meeting'],
+'scheduler'=>[ 'label' => 'Find a meeting date']]" />
+<x-h1 :variable123-with-hyphen=" ['array'=>123]"/>
+<div>
+<x-h1 :variable1=" [
+'key1'=>123,
+'key2'=>'value2',
+]" :message="$message" :variable2=" [
+'key1'=>123,
+'key2'=>'value2',
+]"/>
+</div>
+    <x-aaa color="purple" :foo="aaa" />
+    <x-menu color="purple" :foo="aaa">
+        <x-menu.item>...</x-menu.item>
+        <x-menu.item>...</x-menu.item>
+    </x-menu>
+    <x-alert type="error" :message=" $message" class="mb-4" />
+    <div :foo="aaaa ">
+    </div>
+    <div :foo="aaaa" />
+    <div :aaa="aaaa">
+    </div>
+    <foo :hoge="aaa">
+    </foo>
+    <x-app>
+        <x-slot name="title">
+            Laravel Components
+        </x-slot>
+
+        <x-slot name="sidebar">
+            <p>add this to sidebar</p>
+        </x-slot>
+
+        <h1 class="text-2xl">Laravel Components</h1>
+        <x-app>
+            <h1 class="text-2xl">Laravel Components</h1>
+            <x-alert :message="$message" />
+        </x-app>
+        <x-app>
+            <h1 class="text-2xl">Laravel Components</h1>
+            <x-alert :message='$message' />
+        </x-app>
+    </x-app>
+<x-h1 :modifiers="
+
+['no-margin'=>true]
+
+"></x-h1>
+
+<x-form-group name="interests" label="Pick one or more interests">
+    <x-form-checkbox name="interests[]" :show-errors="false" value="laravel" label="Laravel" />
+    <x-form-checkbox name="interests[]" :show-errors="false" value="tailwindcss" label="Tailwind CSS" />
+</x-form-group>
+<x-laravel-blade-sortable::sortable>
+    <x-laravel-blade-sortable::sortable-item sort-key="jason">
+        Jason
+    </x-laravel-blade-sortable::sortable-item>
+    <x-laravel-blade-sortable::sortable-item sort-key="andres">
+        Andres
+    </x-laravel-blade-sortable::sortable-item>
+    <x-laravel-blade-sortable::sortable-item sort-key="matt">
+        Matt
+    </x-laravel-blade-sortable::sortable-item>
+    <x-laravel-blade-sortable::sortable-item sort-key="james">
+        James
+    </x-laravel-blade-sortable::sortable-item>
+</x-laravel-blade-sortable::sortable>
+<x-laravel-blade-sortable::sortable
+    name="dropzone"
+    wire:onSortOrderChange="handleSortOrderChange"
+>
+    {{-- Items here --}}
+</x-laravel-blade-sortable::sortable>
+<x-alert type="error" :message="1" class="mb-4" />
+<x-alert type="error" :message="'foo'" class="mb-4" />
+<x-alert type="error" :message="," class="mb-4" />
+@endsection

--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -6,6 +6,12 @@
             'scheduler' => ['label' => 'Find a meeting date'],
         ]" />
     <x-h1 :variable123-with-hyphen="['array' => 123]" />
+    <x-h1 legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type" :variable123-with-hyphen="[
+        'array' => 123,
+        'series' => ['label' => 'Recurring meeting'],
+        'series2' => ['label' => 'Recurring meeting'],
+        'series3' => ['label' => 'Recurring meeting'],
+    ]" />
     <div>
         <x-h1 :variable1="[
             'key1' => 123,

--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -1,0 +1,76 @@
+@section('body')
+    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"
+        :inline="true" :options="[
+            'single' => ['label' => 'Default'],
+            'series' => ['label' => 'Recurring meeting'],
+            'scheduler' => ['label' => 'Find a meeting date'],
+        ]" />
+    <x-h1 :variable123-with-hyphen="['array' => 123]" />
+    <div>
+        <x-h1 :variable1="[
+            'key1' => 123,
+            'key2' => 'value2',
+        ]" :message="$message" :variable2="[
+            'key1' => 123,
+            'key2' => 'value2',
+        ]" />
+    </div>
+    <x-aaa color="purple" :foo="aaa" />
+    <x-menu color="purple" :foo="aaa">
+        <x-menu.item>...</x-menu.item>
+        <x-menu.item>...</x-menu.item>
+    </x-menu>
+    <x-alert type="error" :message="$message" class="mb-4" />
+    <div :foo="aaaa">
+    </div>
+    <div :foo="aaaa" />
+    <div :aaa="aaaa">
+    </div>
+    <foo :hoge="aaa">
+    </foo>
+    <x-app>
+        <x-slot name="title">
+            Laravel Components
+        </x-slot>
+
+        <x-slot name="sidebar">
+            <p>add this to sidebar</p>
+        </x-slot>
+
+        <h1 class="text-2xl">Laravel Components</h1>
+        <x-app>
+            <h1 class="text-2xl">Laravel Components</h1>
+            <x-alert :message="$message" />
+        </x-app>
+        <x-app>
+            <h1 class="text-2xl">Laravel Components</h1>
+            <x-alert :message='$message' />
+        </x-app>
+    </x-app>
+    <x-h1 :modifiers="['no-margin' => true]"></x-h1>
+
+    <x-form-group name="interests" label="Pick one or more interests">
+        <x-form-checkbox name="interests[]" :show-errors="false" value="laravel" label="Laravel" />
+        <x-form-checkbox name="interests[]" :show-errors="false" value="tailwindcss" label="Tailwind CSS" />
+    </x-form-group>
+    <x-laravel-blade-sortable::sortable>
+        <x-laravel-blade-sortable::sortable-item sort-key="jason">
+            Jason
+        </x-laravel-blade-sortable::sortable-item>
+        <x-laravel-blade-sortable::sortable-item sort-key="andres">
+            Andres
+        </x-laravel-blade-sortable::sortable-item>
+        <x-laravel-blade-sortable::sortable-item sort-key="matt">
+            Matt
+        </x-laravel-blade-sortable::sortable-item>
+        <x-laravel-blade-sortable::sortable-item sort-key="james">
+            James
+        </x-laravel-blade-sortable::sortable-item>
+    </x-laravel-blade-sortable::sortable>
+    <x-laravel-blade-sortable::sortable name="dropzone" wire:onSortOrderChange="handleSortOrderChange">
+        {{-- Items here --}}
+    </x-laravel-blade-sortable::sortable>
+    <x-alert type="error" :message="1" class="mb-4" />
+    <x-alert type="error" :message="'foo'" class="mb-4" />
+    <x-alert type="error" :message="," class="mb-4" />
+@endsection

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -516,7 +516,7 @@ export default class Formatter {
   async preserveComponentAttribute(content: string) {
     return _.replace(
       content,
-      /(?<=.*?<x-.*?):[a-zA-Z0-9.\-_.]*?=(["']).*?\1(?=.*?\/*?>)/gis,
+      /(?<=<x-.*?):[a-zA-Z0-9.\-_.]*?=(["']).*?\1(?=.*?\/*?>)/gis,
       (match: any) => `${this.storeComponentAttribute(match)}`,
     );
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -965,6 +965,10 @@ export default class Formatter {
       return content;
     }
 
+    if (this.isInline(content)) {
+      return `${content}`;
+    }
+
     if (this.isInline(content) && /\S/.test(prefix)) {
       return `${content}`;
     }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1326,7 +1326,7 @@ export default class Formatter {
         const matched = this.componentAttributes[p1];
         const formatted = _.replace(matched, /(?<=:.*?=(["'])).*?(?=\1)/gis, (match) => {
           try {
-            return util.formatRawStringAsPhp(match, this.options.wrapLineLength - indent.amount).trimEnd();
+            return util.formatRawStringAsPhp(match, this.wrapLineLength - indent.amount).trimEnd();
           } catch (error) {
             return match;
           }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1326,7 +1326,7 @@ export default class Formatter {
         const matched = this.componentAttributes[p1];
         const formatted = _.replace(matched, /(?<=:.*?=(["'])).*?(?=\1)/gis, (match) => {
           try {
-            return util.formatRawStringAsPhp(match).trimEnd();
+            return util.formatRawStringAsPhp(match, this.options.wrapLineLength - indent.amount).trimEnd();
           } catch (error) {
             return match;
           }


### PR DESCRIPTION
- fix: 🐛 blade component attribute indents forever
- test: 💍 add test for component attribute

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #541

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #541

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Blade component with attribute should keep its indent position.

e.g.

```blade
    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"
        :inline="true" :options="[
            'single' => ['label' => 'Default'],
            'series' => ['label' => 'Recurring meeting'],
            'scheduler' => ['label' => 'Find a meeting date'],
        ]" />
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

see tests
