### PR TITLE
fix: colon prefixed attribute may cause unexpected format

### DIFF
--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -27,7 +27,7 @@
         <x-menu.item>...</x-menu.item>
     </x-menu>
     <x-alert type="error" :message="$message" class="mb-4" />
-    <div :foo="aaaa">
+    <div :foo="aaaa ">
     </div>
     <div :foo="aaaa" />
     <div :aaa="aaaa">

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2924,4 +2924,31 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('colon prefixed attribute #552', async () => {
+    const content = [
+      `<x-app-layout>`,
+      `@if ($user)`,
+      `Is HR`,
+      `@endif`,
+      `</x-app-layout>`,
+      `<tbody x-data class="divide-y divide-gray-200 bg-gray-50">`,
+      `<template x-for="shipment in in_progress" :key="shipment.id" />`,
+      `</tbody>`,
+    ].join('\n');
+
+    const expected = [
+      `<x-app-layout>`,
+      `    @if ($user)`,
+      `        Is HR`,
+      `    @endif`,
+      `</x-app-layout>`,
+      `<tbody x-data class="divide-y divide-gray-200 bg-gray-50">`,
+      `    <template x-for="shipment in in_progress" :key="shipment.id" />`,
+      `</tbody>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -520,7 +520,7 @@ export default class Formatter {
   async preserveComponentAttribute(content: string) {
     return _.replace(
       content,
-      /(?<=<x-.*?\s):{1,2}[a-zA-Z0-9.\-_.:]*?=(["']).*?\1(?=.*?\/*?>)/gis,
+      /(?<=<x-[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\1(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeComponentAttribute(match)}`,
     );
   }


### PR DESCRIPTION
- fix: 🐛 colon prefixed attribute gets unexpected format
- test: 💍 fix test case to follow current behaviour
- test: 💍 add test case for colon prefixed attribute

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #552

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #552

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

No format should be applied except for component attributes beginning with `x-`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
