### PR TITLE
fix: shorthand bindings gets unexpexted indentation

### DIFF
--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -27,7 +27,7 @@
         <x-menu.item>...</x-menu.item>
     </x-menu>
     <x-alert type="error" :message="$message" class="mb-4" />
-    <div :foo="aaaa ">
+    <div :foo="aaaa">
     </div>
     <div :foo="aaaa" />
     <div :aaa="aaaa">

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2951,4 +2951,41 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('shorthand binding #557', async () => {
+    const content = [
+      `@section('body')`,
+      `    <forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"`,
+      `        :inline="true"`,
+      `        :options="[`,
+      `    'single' => ['label' => 'Default'],`,
+      `    'series' => ['label' => 'Recurring meeting'],`,
+      `    'scheduler' => ['label' => 'Find a meeting date'],`,
+      `]" />`,
+      `@endsection`,
+    ].join('\n');
+
+    const expected = [
+      `@section('body')`,
+      `    <forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"`,
+      `        :inline="true"`,
+      `        :options="[`,
+      `            'single' => ['label' => 'Default'],`,
+      `            'series' => ['label' => 'Recurring meeting'],`,
+      `            'scheduler' => ['label' => 'Find a meeting date'],`,
+      `        ]" />`,
+      `@endsection`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('x-bind binding', async () => {
+    const content = [`<div x-bind:class="imageLoaded?'blur-none':'blur-3xl'">`, `</div>`].join('\n');
+
+    const expected = [`<div x-bind:class="imageLoaded ? 'blur-none' : 'blur-3xl'">`, `</div>`, ``].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 
 import os from 'os';
-import beautify from 'js-beautify';
+import beautify, { JSBeautifyOptions } from 'js-beautify';
 import _ from 'lodash';
 import * as vscodeTmModule from 'vscode-textmate';
 import detectIndent from 'detect-indent';


### PR DESCRIPTION
- fix: 🐛 shorthand bindings gets unexpected indentation
- test: 💍 fix test case to follow current behaviour
- test: 💍 add test case for shorthand bindings

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #557

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #557
- fixes: https://github.com/shufo/vscode-blade-formatter/issues/402

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Shorthand binding should also be handled correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
