### PR TITLE
fix: 🐛 prevent set directive to be wrapped

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2988,4 +2988,17 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@set directive #542', async () => {
+    const content = [
+      `@set($myVariableWithVeryVeryVeryVeryVeryLongName = ($myFirstCondition || $mySecondCondition)?'My text':'My alternative text')`,
+    ].join('\n');
+
+    const expected = [
+      `@set($myVariableWithVeryVeryVeryVeryVeryLongName = $myFirstCondition || $mySecondCondition ? 'My text' : 'My alternative text')`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -104,6 +104,7 @@ export const phpKeywordStartTokens = ['@forelse', '@if', '@for', '@foreach', '@w
 export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endforeach', '@endfor', '@endwhile', '@break'];
 
 export const inlineFunctionTokens = [
+  '@set',
   '@json',
   '@selected',
   '@checked',


### PR DESCRIPTION
✅ Closes: #542

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #542

Template like below preserve its format

```blade
@set($myVariableWithVeryVeryVeryVeryVeryLongName = ($myFirstCondition || $mySecondCondition) ? 'My text' : 'My alternative text')
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #542

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
