### PR TITLE
fix: 🐛 component directive argument lose indentation

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3001,4 +3001,52 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@component directive indentation', async () => {
+    const content = [
+      `<div>`,
+      `        <div>`,
+      `@component('path.to.component', [`,
+      `    'title' => 'My title',`,
+      `'description' => '',`,
+      `    'header' => [`,
+      `        'transparent' => true,`,
+      `                  ],`,
+      `  'footer' => [`,
+      `        'hide' => true,`,
+      `    ],`,
+      `            ])`,
+      `    <div>`,
+      `        some content`,
+      `            </div>`,
+      `          @endcomponent`,
+      `</div>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    <div>`,
+      `        @component('path.to.component',`,
+      `            [`,
+      `                'title' => 'My title',`,
+      `                'description' => '',`,
+      `                'header' => [`,
+      `                    'transparent' => true,`,
+      `                ],`,
+      `                'footer' => [`,
+      `                    'hide' => true,`,
+      `                ],`,
+      `            ])`,
+      `            <div>`,
+      `                some content`,
+      `            </div>`,
+      `        @endcomponent`,
+      `    </div>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1134,11 +1134,19 @@ export default class Formatter {
   restoreConditions(content: any) {
     return new Promise((resolve) => resolve(content)).then((res: any) =>
       _.replace(res, new RegExp(`${this.getConditionPlaceholder('(\\d+)')}`, 'gms'), (_match: any, p1: any) => {
+        const placeholder = this.getConditionPlaceholder(p1);
+        const matchedLine = content.match(new RegExp(`^(.*?)${placeholder}`, 'gmi')) ?? [''];
+        const indent = detectIndent(matchedLine[0]);
+
         const matched = this.conditions[p1];
-        return util
-          .formatRawStringAsPhp(matched)
-          .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-          .trimEnd();
+
+        return this.indentComponentAttribute(
+          indent.indent,
+          util
+            .formatRawStringAsPhp(matched)
+            .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+            .trimEnd(),
+        );
       }),
     );
   }

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -119,7 +119,7 @@ export const inlineFunctionTokens = [
   '@class',
 ];
 
-export const conditionalTokens = ['@if', '@while', '@case', '@isset', '@empty', '@elseif'];
+export const conditionalTokens = ['@if', '@while', '@case', '@isset', '@empty', '@elseif', '@component'];
 
 export function hasStartAndEndToken(tokenizeLineResult: any, originalLine: any) {
   return (


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/prettier-plugin-blade/issues/58

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/58.

### Behaviour

```blade
<div>
        <div>
@component(     'path.to.component',[
    'title' => 'My title',
'description' => '',
    'header' => [
        'transparent' => true,
                  ],
  'footer' => [
        'hide' => true,
    ],
            ])
    <div>
        some content
            </div>
          @endcomponent
</div>
</div>
```

will format into

```blade
<div>
    <div>
        @component('path.to.component',
            [
                'title' => 'My title',
                'description' => '',
                'header' => [
                    'transparent' => true,
                ],
                'footer' => [
                    'hide' => true,
                ],
            ])
            <div>
                some content
            </div>
        @endcomponent
    </div>
</div>
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/58

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We should keeep indentation of component directive arguments.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
