### PR TITLE
fix: 🐛 long inline blade braces adds unexpected line break

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3049,4 +3049,24 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('long inline brade braces', async () => {
+    const content = [
+      `<input id="combobox" type="text" placeholder="{{ $itemsPlaceholder }}" role="combobox" aria-controls="options"`,
+      `       aria-expanded="false" x-on:keydown.up.prevent="hoverPreviousItem()"`,
+      `       x-on:keydown.enter.stop.prevent="selectItem()" x-on:keydown.down.prevent="hoverNextItem()" x-ref="input"`,
+      `       x-model="input"`,
+      `       class="form-input focus:border-blue-good-standard-light focus:ring-blue-good-standard-light {{ empty($selectedItemIds)?'placeholder:text-blue-good-standard-light focus:placeholder:text-blue-good-standard-dark':'placeholder:text-gray-good-standard-light focus:placeholder:text-gray-good-standard-dark' }} {{ $inputClasses }} w-full rounded-md border border-gray-300 bg-white py-2 pr-3 pl-12 text-base shadow-sm transition-all placeholder:font-medium focus:outline-none focus:ring-1">`,
+    ].join('\n');
+
+    const expected = [
+      `<input id="combobox" type="text" placeholder="{{ $itemsPlaceholder }}" role="combobox" aria-controls="options"`,
+      `    aria-expanded="false" x-on:keydown.up.prevent="hoverPreviousItem()" x-on:keydown.enter.stop.prevent="selectItem()"`,
+      `    x-on:keydown.down.prevent="hoverNextItem()" x-ref="input" x-model="input"`,
+      `    class="form-input focus:border-blue-good-standard-light focus:ring-blue-good-standard-light {{ empty($selectedItemIds) ? 'placeholder:text-blue-good-standard-light focus:placeholder:text-blue-good-standard-dark' : 'placeholder:text-gray-good-standard-light focus:placeholder:text-gray-good-standard-dark' }} {{ $inputClasses }} w-full rounded-md border border-gray-300 bg-white py-2 pr-3 pl-12 text-base shadow-sm transition-all placeholder:font-medium focus:outline-none focus:ring-1">`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1070,7 +1070,7 @@ export default class Formatter {
 
           if (this.isInline(bladeBrace)) {
             return `${p1}{{ ${util
-              .formatRawStringAsPhp(bladeBrace, 120, false)
+              .formatRawStringAsPhp(bladeBrace, 1000, false)
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
               .split('\n')
               .map((line) => line.trim())


### PR DESCRIPTION
- fix: 🐛 long inline blade braces adds unexpected line break
- test: 💍 add test for long inline blade braces

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/409

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/409

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Long line inline blade braces should keep its format.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
