### PR TITLE
fix: 🐛 dollar sign may cause formatting errors

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3069,4 +3069,31 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('special character in replacement parameter #565', async () => {
+    const content = [
+      `@section('foo')`,
+      `    <script>`,
+      `        alert('$');`,
+      `        alert('$$');`,
+      `        alert('$$$');`,
+      `        alert('$$$$');`,
+      `    </script>`,
+      `@endsection`,
+    ].join('\n');
+
+    const expected = [
+      `@section('foo')`,
+      `    <script>`,
+      `        alert('$');`,
+      `        alert('$$');`,
+      `        alert('$$$');`,
+      `        alert('$$$$');`,
+      `    </script>`,
+      `@endsection`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -468,7 +468,7 @@ export default class Formatter {
             );
 
             // eslint-disable-next-line
-            content = _.replace(content, matched.value, replaced);
+            content = _.replace(content, matched.value, util.escapeReplacementString(replaced));
           }
         }
       } catch (error) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -317,6 +317,10 @@ export function checkResult(formatted: any) {
   return formatted;
 }
 
+export function escapeReplacementString(string: string) {
+  return string.replace(/\$/g, '$$$$');
+}
+
 export function debugLog(content: any) {
   console.log('content start');
   console.log(content);

--- a/src/util.ts
+++ b/src/util.ts
@@ -322,9 +322,9 @@ export function escapeReplacementString(string: string) {
 }
 
 export function debugLog(content: any) {
-  console.log('content start');
+  console.log('------------------- content start -------------------');
   console.log(content);
-  console.log('content end');
+  console.log('------------------- content end   -------------------');
 
   return content;
 }


### PR DESCRIPTION
- fix: 🐛 dollar sign may cause formatting errors

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #565.
Formatting error occurs if dollar sign exists between directives.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #565

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even when dollar signs are present, they should not be interpreted as special symbols for `prototype.replace` function.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
