### PR TITLE
fix: 🐛 livewire tag causes unexpected formatting

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3096,4 +3096,29 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('livewire tag', async () => {
+    const content = [
+      `<div class="mt-6">`,
+      `    @foreach ($this->relations as $k => $relation )`,
+      `    <div x-show="tab == '#tab{{$k}}'" x-cloak>`,
+      `        <livewire:widgets.invoice-document-consumption.card :invoice_document_id="$this->     invoiceDocument->id" />`,
+      `    </div>`,
+      `    @endforeach`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div class="mt-6">`,
+      `    @foreach ($this->relations as $k => $relation)`,
+      `        <div x-show="tab == '#tab{{ $k }}'" x-cloak>`,
+      `            <livewire:widgets.invoice-document-consumption.card :invoice_document_id="$this->invoiceDocument->id" />`,
+      `        </div>`,
+      `    @endforeach`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -525,7 +525,7 @@ export default class Formatter {
   async preserveShorthandBinding(content: string) {
     return _.replace(
       content,
-      /(?<=<(?!livewire)[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
+      /(?<=<(?!livewire:)[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeShorthandBinding(match)}`,
     );
   }
@@ -533,7 +533,7 @@ export default class Formatter {
   async preserveComponentAttribute(content: string) {
     return _.replace(
       content,
-      /(?<=<(x-|livewire)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
+      /(?<=<(x-|livewire:)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeComponentAttribute(match)}`,
     );
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -525,8 +525,7 @@ export default class Formatter {
   async preserveShorthandBinding(content: string) {
     return _.replace(
       content,
-      // /(?<=<[^<]*?(\s|x-bind):{1}(?<!=>)[\w\-_.]*?=(["']))(?!=>)[^]*?(?=\2[^>]*?\/*?>)/gim,
-      /(?<=<[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
+      /(?<=<(?!livewire)[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeShorthandBinding(match)}`,
     );
   }
@@ -534,7 +533,7 @@ export default class Formatter {
   async preserveComponentAttribute(content: string) {
     return _.replace(
       content,
-      /(?<=<x-[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\1(?=[^>]*?\/*?>)/gim,
+      /(?<=<(x-|livewire)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeComponentAttribute(match)}`,
     );
   }


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/prettier-plugin-blade/issues/65

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/65

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/65

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Livewire tag attributes should be formatted as php expression.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
