### PR TITLE
fix: timeout on @isset~@endif directive in html tag

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3579,4 +3579,19 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('it should not time out on @isset~@endif directive in html tag #585', async () => {
+    const content = [
+      `<input type="text" name="{{ 'flow_locales['.$index.'][title]' }}"`,
+      `    @isset($flow->locale) value="{{ $flow->locale['title'] }}" @endif>`,
+    ].join('\n');
+
+    const expected = [
+      `<input type="text" name="{{ 'flow_locales[' . $index . '][title]' }}"`,
+      `    @isset($flow->locale) value="{{ $flow->locale['title'] }}" @endif>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -354,29 +354,18 @@ export default class Formatter {
   preserveInlineDirective(content: string): string {
     // preserve inline directives inside html tag
     const regex = new RegExp(
-      `(<[\\w]+?[^>]*?)${directivePrefix}(${indentStartTokensWithoutPrefix.join(
+      `(?<=<[\\w]+?[^>]*?)${directivePrefix}(${indentStartTokensWithoutPrefix.join(
         '|',
-        // eslint-disable-next-line max-len
-      )})(\\s*?)(${nestedParenthesisRegex})(.*?)(@end\\2)(.*?>)`,
+      )})(\\s*?)(\\(.*?\\))(.*?)(@end\\1|@endif)(?=.*?>)`,
       'gims',
     );
     const replaced = _.replace(
       content,
       regex,
-      (
-        _match: string,
-        p1: string,
-        p2: string,
-        p3: string,
-        p4: string,
-        p5: string,
-        p6: string,
-        p7: string,
-        p8: string,
-      ) => {
-        return `${p1}${this.storeInlineDirective(
-          `${directivePrefix}${p2.trim()}${p3}${p4.trim()} ${p6.trim()} ${p7.trim()}`,
-        )}${p8}`;
+      (_match: string, p1: string, p2: string, p3: string, p4: string, p5: string) => {
+        return `${this.storeInlineDirective(
+          `${directivePrefix}${p1.trim()}${p2}${p3.trim()} ${p4.trim()} ${p5.trim()}`,
+        )}`;
       },
     );
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -354,9 +354,9 @@ export default class Formatter {
   preserveInlineDirective(content: string): string {
     // preserve inline directives inside html tag
     const regex = new RegExp(
-      `(?<=<[\\w]+?[^>]*?)${directivePrefix}(${indentStartTokensWithoutPrefix.join(
+      `(?<=<[\\w\\-\\_]+?[^>]*?)${directivePrefix}(${indentStartTokensWithoutPrefix.join(
         '|',
-      )})(\\s*?)(\\(.*?\\))(.*?)(@end\\1|@endif)(?=.*?>)`,
+      )})(\\s*?)(\\(.*?\\))(.*?)(@end\\1|@endif)(?=.*?/*>)`,
       'gims',
     );
     const replaced = _.replace(


### PR DESCRIPTION
- fix: 🐛 timeout on isset~endif directive in html tag
- test: 💍 add test for isset~endif directive in html tag

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #585

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #585

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should not timeout on `@isset~@endif` directive exists in html tag

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
