### PR TITLE
fix: 🐛 empty class string results in unexpected formatting

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3594,4 +3594,33 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('it should keep format even if sort target class string is empty', async () => {
+    const content = [
+      `<div class="">`,
+      `    @php`,
+      `        switch ($color) {`,
+      `            case 'white':`,
+      `                $colorClasses = 'bg-white';`,
+      `                break;`,
+      `        }`,
+      `    @endphp`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div class="">`,
+      `    @php`,
+      `        switch ($color) {`,
+      `            case 'white':`,
+      `                $colorClasses = 'bg-white';`,
+      `                break;`,
+      `        }`,
+      `    @endphp`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -227,8 +227,12 @@ export default class Formatter {
       return content;
     }
 
-    return _.replace(content, /\bclass\s*=\s*([\"\'])(.+?)([\"\'])/gis, (_match, p1, p2, p3) => {
-      return `class=${p1}${sortClasses(p2)}${p3}`;
+    return _.replace(content, /(?<=\bclass\s*=\s*([\"\']))(.*?)(?=\1)/gis, (_match, p1, p2) => {
+      if (_.isEmpty(p2)) {
+        return p2;
+      }
+
+      return sortClasses(p2);
     });
   }
 


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/417

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/417
When the content of class attribute is empty and sortTailwindcssClass option is true, the regular expression matches unexpected result.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/417

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Formatter should keep its format even if the class string is empty and the sort option of tailwindcss class is true

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
