### PR TITLE
fix: 🐛 format broken by x-bind:class when class sort enabled

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3639,6 +3639,6 @@ describe('formatter', () => {
       ``,
     ].join('\n');
 
-    await util.doubleFormatCheck(content, expected);
+    await util.doubleFormatCheck(content, expected, { sortTailwindcssClasses: true });
   });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3623,4 +3623,22 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('it should not match x-bind:class sort class regex', async () => {
+    const content = [
+      `<div x-bind:class="{ 'mb-3 pb-3 border-b-2 border-light-gray': what }" @class([`,
+      `                 'flex w-full items-center',`,
+      `                      $boxClasses,`,
+      `                            ])>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div x-bind:class="{ 'mb-3 pb-3 border-b-2 border-light-gray': what }" @class(['flex w-full items-center', $boxClasses])>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -227,7 +227,7 @@ export default class Formatter {
       return content;
     }
 
-    return _.replace(content, /(?<=\bclass\s*=\s*([\"\']))(.*?)(?=\1)/gis, (_match, p1, p2) => {
+    return _.replace(content, /(?<=\s+(?!:)class\s*=\s*([\"\']))(.*?)(?=\1)/gis, (_match, p1, p2) => {
       if (_.isEmpty(p2)) {
         return p2;
       }


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/421

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/421

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/421

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current regex to extract class attribute unexpectedly matching `x-bind:class` attribute

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
