### PR TITLE
fix: 🐛 nested forelse directive results in unexpected format

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3721,4 +3721,41 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected, { wrapAttributes: 'force-expand-multiline' });
   });
+
+  test('nested @forelse https://github.com/shufo/vscode-blade-formatter/issues/425', async () => {
+    const content = [
+      `@forelse($users as $user)`,
+      `@if ($user)`,
+      `foo`,
+      `@forelse($users as $user)`,
+      `  foo`,
+      `  @empty`,
+      `  bar`,
+      `  @endforelse`,
+      `  @endif`,
+      `baz`,
+      `@empty`,
+      `something goes here`,
+      `@endforelse`,
+    ].join('\n');
+
+    const expected = [
+      `@forelse($users as $user)`,
+      `    @if ($user)`,
+      `        foo`,
+      `        @forelse($users as $user)`,
+      `            foo`,
+      `        @empty`,
+      `            bar`,
+      `        @endforelse`,
+      `    @endif`,
+      `    baz`,
+      `@empty`,
+      `    something goes here`,
+      `@endforelse`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -106,7 +106,7 @@ export const optionalStartWithoutEndTokens = {
   '@slot': 2,
 };
 
-export const tokenForIndentStartOrElseTokens = ['@forelse'];
+export const tokenForIndentStartOrElseTokens = ['@forelse', '@if'];
 
 export const indentStartOrElseTokens = ['@empty'];
 


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/425

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/425

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/425

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`@forelse~@empty~@endforelse` directive should be peroperly formatted even if they are in `@forelse~@if~@endif~@empty~@endforelse`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
