### PR TITLE
fix: 🐛 at-rules of css results in Syntax Error

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3769,4 +3769,56 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('css at rule https://github.com/shufo/vscode-blade-formatter/issues/430', async () => {
+    const content = [
+      `@section('css')`,
+      `    <style>`,
+      `        .card-body+.card-body {`,
+      `        margin-top: 20px !important;`,
+      `     padding-top: 20px !important;`,
+      `   border-top: 1px solid #e3ebf6;`,
+      `        }`,
+      ``,
+      `        @media(max-width:   992px) {`,
+      `            .remove-border-end-on-mobile {`,
+      `            border-right: 0 none !important;`,
+      `            }`,
+      ``,
+      `            .remove-border-end-on-mobile .card-body {`,
+      `border-bottom: 1px solid #e3ebf6;`,
+      `            padding-bottom: 20px !important;`,
+      `            }`,
+      `        }`,
+      `    </style>`,
+      `@endsection`,
+    ].join('\n');
+
+    const expected = [
+      `@section('css')`,
+      `    <style>`,
+      `        .card-body+.card-body {`,
+      `            margin-top: 20px !important;`,
+      `            padding-top: 20px !important;`,
+      `            border-top: 1px solid #e3ebf6;`,
+      `        }`,
+      ``,
+      `        @media(max-width: 992px) {`,
+      `            .remove-border-end-on-mobile {`,
+      `                border-right: 0 none !important;`,
+      `            }`,
+      ``,
+      `            .remove-border-end-on-mobile .card-body {`,
+      `                border-bottom: 1px solid #e3ebf6;`,
+      `                padding-bottom: 20px !important;`,
+      `            }`,
+      `        }`,
+      ``,
+      `    </style>`,
+      `@endsection`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -27,6 +27,7 @@ import {
   directivePrefix,
   indentStartTokensWithoutPrefix,
   unbalancedStartTokens,
+  cssAtRuleTokens,
 } from './indent';
 import { nestedParenthesisRegex } from './regex';
 
@@ -309,6 +310,7 @@ export default class Formatter {
       ...phpKeywordStartTokens,
       ...['@unless[a-z]*\\(.*?\\)'],
       ...unbalancedStartTokens,
+      ...cssAtRuleTokens,
     ].join('|');
 
     const inlineRegex = new RegExp(

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -148,6 +148,21 @@ export const conditionalTokens = [
 
 export const unbalancedStartTokens = ['@hassection'];
 
+export const cssAtRuleTokens = [
+  '@charset',
+  '@color-profile',
+  '@counter-style',
+  '@font-face',
+  '@font-feature-values',
+  '@import',
+  '@keyframes',
+  '@media',
+  '@namespace',
+  '@page',
+  '@property',
+  '@supports',
+];
+
 export function hasStartAndEndToken(tokenizeLineResult: any, originalLine: any) {
   return (
     _.filter(tokenizeLineResult.tokens, (tokenStruct: any) => {


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/430

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/430

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/430

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unexpected Syntax Error occurs when [CSS at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) is recognized as a custom directive.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
