### PR TITLE
fix: 🐛 new line inserted at end of style tag

### DIFF
--- a/__tests__/fixtures/formatted.append_tag.blade.php
+++ b/__tests__/fixtures/formatted.append_tag.blade.php
@@ -5,7 +5,6 @@
 
                 text-decoration: underline !important;
             }
-
         </style>
     @append
 </div>

--- a/__tests__/fixtures/formatted.multiline_blade_comment.blade.php
+++ b/__tests__/fixtures/formatted.multiline_blade_comment.blade.php
@@ -8,7 +8,6 @@ this images is example --}}
     .original-image-tag {
         white-space: nowrap;
     }
-
 </style>
 <script>
     $('.original-image-input').on('change', handleUpload);

--- a/__tests__/fixtures/formatted.overwrite_tag.blade.php
+++ b/__tests__/fixtures/formatted.overwrite_tag.blade.php
@@ -5,7 +5,6 @@
 
                 text-decoration: underline !important;
             }
-
         </style>
     @overwrite
 </div>

--- a/__tests__/fixtures/formatted_shorttag.blade.php
+++ b/__tests__/fixtures/formatted_shorttag.blade.php
@@ -339,7 +339,6 @@
         a.status-1 {
             font-weight: bold;
         }
-
     </style>
     <script>
         jQuery(document).ready(function($) {

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3813,7 +3813,6 @@ describe('formatter', () => {
       `                padding-bottom: 20px !important;`,
       `            }`,
       `        }`,
-      ``,
       `    </style>`,
       `@endsection`,
       ``,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -211,6 +211,9 @@ export default class Formatter {
       wrap_line_length: util.optional(this.options).wrapLineLength || 120,
       wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
       end_with_newline: util.optional(this.options).endWithNewline || true,
+      css: {
+        end_with_newline: false,
+      },
     };
 
     const promise = new Promise((resolve) => resolve(data))


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/385

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/385

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/385

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should not insert new line at end of style tag.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
