### PR TITLE
fix: 🐛 unexpected result when wrap attributes option specified

### DIFF
--- a/__tests__/fixtures/formatted_shorttag.blade.php
+++ b/__tests__/fixtures/formatted_shorttag.blade.php
@@ -520,8 +520,7 @@
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <div class="form-group">
                 <label>Add new keys to this group</label>
-                <textarea class="form-control" rows="3" name="keys"
-                    placeholder="Add 1 key per line, without the group prefix"></textarea>
+                <textarea class="form-control" rows="3" name="keys" placeholder="Add 1 key per line, without the group prefix"></textarea>
             </div>
             <div class="form-group">
                 <input type="submit" value="Add keys" class="btn btn-primary">

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3820,4 +3820,70 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('textarea wrapping https://github.com/shufo/vscode-blade-formatter/issues/414', async () => {
+    const content = [
+      `<body class="bg-background font-sans text-sm text-gray-900"`,
+      `      class="bg-background font-sans text-sm text-gray-900">`,
+      `    <form action="#"`,
+      `          method="POST"`,
+      `          class="space-y-4 py-6">`,
+      `        ...`,
+      `        <!-- Idea Description -->`,
+      `        <div>`,
+      `            <textarea class="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm"`,
+      `                      name="idea_description"`,
+      `                      id="idea-description"`,
+      `                      cols="30"`,
+      `                      rows="4"`,
+      `                      data="{'aa' => '123'}" x-foo="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm" x-bar="321"`,
+      `            data-x="aa123">               </textarea>`,
+      `        </div>`,
+      `    </form>`,
+      `</body>`,
+    ].join('\n');
+
+    const alignedMultipleExpected = [
+      `<body class="bg-background font-sans text-sm text-gray-900" class="bg-background font-sans text-sm text-gray-900">`,
+      `    <form action="#" method="POST" class="space-y-4 py-6">`,
+      `        ...`,
+      `        <!-- Idea Description -->`,
+      `        <div>`,
+      `            <textarea class="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm" name="idea_description"`,
+      `                      id="idea-description" cols="30" rows="4" data="{'aa' => '123'}"`,
+      `                      x-foo="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm" x-bar="321" data-x="aa123">               </textarea>`,
+      `        </div>`,
+      `    </form>`,
+      `</body>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, alignedMultipleExpected, { wrapAttributes: 'aligned-multiple' });
+
+    const forceAlignedExpected = [
+      `<body class="bg-background font-sans text-sm text-gray-900"`,
+      `      class="bg-background font-sans text-sm text-gray-900">`,
+      `    <form action="#"`,
+      `          method="POST"`,
+      `          class="space-y-4 py-6">`,
+      `        ...`,
+      `        <!-- Idea Description -->`,
+      `        <div>`,
+      `            <textarea class="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm"`,
+      `                      name="idea_description"`,
+      `                      id="idea-description"`,
+      `                      cols="30"`,
+      `                      rows="4"`,
+      `                      data="{'aa' => '123'}"`,
+      `                      x-foo="good-rounded good-border w-full bg-gray-100 px-4 py-2 text-sm"`,
+      `                      x-bar="321"`,
+      `                      data-x="aa123">               </textarea>`,
+      `        </div>`,
+      `    </form>`,
+      `</body>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, forceAlignedExpected, { wrapAttributes: 'force-aligned' });
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1705,12 +1705,20 @@ export default class Formatter {
           indent_size: util.optional(this.options).indentSize || 4,
           wrap_line_length: util.optional(this.options).wrapLineLength || 120,
           wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
-          wrap_attributes_indent_size: indent.amount + (util.optional(this.options).indentSize || 4) * 1,
           end_with_newline: false,
           templating: ['php'],
         };
 
-        return `${beautify.html_beautify(this.htmlTags[p1], options)}`;
+        const matched = this.htmlTags[p1];
+        const openingTag = _.first(matched.match(/(<(textarea|pre).*?(?<!=)>)(?=.*?<\/\2>)/gis));
+
+        if (openingTag === undefined) {
+          return `${this.indentScriptBlock(indent, beautify.html_beautify(matched, options))}`;
+        }
+
+        const restofTag = matched.substring(openingTag.length, matched.length);
+
+        return `${this.indentScriptBlock(indent, beautify.html_beautify(openingTag, options))}${restofTag}`;
       },
     );
   }


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/414, https://github.com/shufo/vscode-blade-formatter/issues/432

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/414, https://github.com/shufo/vscode-blade-formatter/issues/432

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: https://github.com/shufo/vscode-blade-formatter/issues/414
- fixes: https://github.com/shufo/vscode-blade-formatter/issues/432

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

textarea tag wrapping results in unexpected indent when wrapAttribute option (`force-aligned`, `aligned-multiple`) specified.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
