### PR TITLE
fix: 🐛 arrow indentifier sometimes results in unexpected format

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3886,4 +3886,10 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, forceAlignedExpected, { wrapAttributes: 'force-aligned' });
   });
+
+  test('arrow identifier in tag', async () => {
+    const content = [`<script src="aaa => 1" >`, `const a = 1;`, `const b  = 2;`, `</script>`].join('\n');
+    const expected = [`<script src="aaa => 1">`, `    const a = 1;`, `    const b = 2;`, `</script>`, ``].join('\n');
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -402,7 +402,7 @@ export default class Formatter {
   }
 
   preserveBladeDirectivesInScripts(content: any) {
-    return _.replace(content, /(?<=<script[^>]*?>)(.*?)(?=<\/script>)/gis, (match: string) => {
+    return _.replace(content, /(?<=<script[^>]*?(?<!=)>)(.*?)(?=<\/script>)/gis, (match: string) => {
       const targetTokens = [...indentStartTokens, ...inlineFunctionTokens];
       if (new RegExp(targetTokens.join('|'), 'gmi').test(match) === false) {
         return match.trim();
@@ -536,7 +536,9 @@ export default class Formatter {
     content = _.replace(
       content,
       new RegExp(
-        `(?<=<.*?>)(${_.without(indentStartTokens, '@php').join('|')})(\\s*)${nestedParenthesisRegex}.*?(?=<.*?>)`,
+        `(?<=<.*?(?<!=)>)(${_.without(indentStartTokens, '@php').join(
+          '|',
+        )})(\\s*)${nestedParenthesisRegex}.*?(?=<.*?>)`,
         'gmis',
       ),
       (match) => {
@@ -547,7 +549,7 @@ export default class Formatter {
     // eslint-disable-next-line
     content = _.replace(
       content,
-      new RegExp(`(?<=<.*?>).*?(${_.without(indentEndTokens, '@endphp').join('|')})(?=<.*?>)`, 'gmis'),
+      new RegExp(`(?<=<.*?(?<!=)>).*?(${_.without(indentEndTokens, '@endphp').join('|')})(?=<.*?>)`, 'gmis'),
       (match) => {
         return `\n${match.trim()}\n`;
       },
@@ -1279,7 +1281,7 @@ export default class Formatter {
       return this.indentBladeDirectiveBlock(indent, this.bladeDirectives[p1]);
     });
 
-    result = _.replace(result, /(?<=<script[^>]*?>)(.*?)(?=<\/script>)/gis, (match: string) => {
+    result = _.replace(result, /(?<=<script[^>]*?(?<!=)>)(.*?)(?=<\/script>)/gis, (match: string) => {
       let formatted: string = match;
 
       // restore begin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Sometimes arrow like identifier `=>` in html attribute results in unexpected format

e.g.

```blade
<script src="1 => 2">
const a = 1;
</script>
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
