### PR TITLE
fix: preserve html attributes

### DIFF
--- a/__tests__/fixtures/formatted.blade_brace_without_space.blade.php
+++ b/__tests__/fixtures/formatted.blade_brace_without_space.blade.php
@@ -25,7 +25,7 @@
                     <li class="breadcrumb-item active" aria-current="page">{{ $_botton_text }}</li>
                 </ol>
             </container>
-            <div style="margin-top: 20px" ;>
+            <div style="margin-top: 20px";>
                 @if (0 < count($errors))
                     <div class="alert alert-danger" role="alert">error</div>
                 @endif

--- a/__tests__/fixtures/formatted_shorttag.blade.php
+++ b/__tests__/fixtures/formatted_shorttag.blade.php
@@ -441,8 +441,8 @@
         <p>Warning, translations are not visible until they are exported back to the app/lang file, using <code>php
                 artisan translation:export</code> command or publish button.</p>
         <div class="alert alert-success success-import" style="display:none;">
-            <p>Done importing, processed <strong class="counter">N</strong> items! Reload this page to refresh
-                the groups!</p>
+            <p>Done importing, processed <strong class="counter">N</strong> items! Reload this page to refresh the
+                groups!</p>
         </div>
         <div class="alert alert-success success-find" style="display:none;">
             <p>Done searching for translations, found <strong class="counter">N</strong> items!</p>
@@ -503,7 +503,7 @@
                     the migrations and imported the translations.</p>
                 <select name="group" id="group" class="form-control group-select">
                     <?php foreach($groups as $key => $value): ?>
-                    <option value="<?php echo $key; ?>" <?php echo $key == $group ? ' selected' : ''; ?>><?php echo $value; ?></option>
+                    <option value="<?php echo $key; ?>"<?php echo $key == $group ? ' selected' : ''; ?>><?php echo $value; ?></option>
                     <?php endforeach; ?>
                 </select>
             </div>
@@ -520,7 +520,8 @@
             <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
             <div class="form-group">
                 <label>Add new keys to this group</label>
-                <textarea class="form-control" rows="3" name="keys" placeholder="Add 1 key per line, without the group prefix"></textarea>
+                <textarea class="form-control" rows="3" name="keys"
+                    placeholder="Add 1 key per line, without the group prefix"></textarea>
             </div>
             <div class="form-group">
                 <input type="submit" value="Add keys" class="btn btn-primary">
@@ -639,8 +640,8 @@
                             <input type="text" name="new-locale" class="form-control" />
                         </div>
                         <div class="col-sm-2">
-                            <button type="submit" class="btn btn-default btn-block" data-disable-with="Adding..">Add new
-                                locale</button>
+                            <button type="submit" class="btn btn-default btn-block" data-disable-with="Adding..">Add
+                                new locale</button>
                         </div>
                     </div>
                 </div>
@@ -648,8 +649,8 @@
         </fieldset>
         <fieldset>
             <legend>Export all translations</legend>
-            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*'); ?>" data-remote="true"
-                role="form"
+            <form class="form-inline form-publish-all" method="POST" action="<?php echo action('\Barryvdh\TranslationManager\Controller@postPublish', '*'); ?>"
+                data-remote="true" role="form"
                 data-confirm="Are you sure you want to publish all translations group? This will overwrite existing language files.">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
                 <button type="submit" class="btn btn-primary" data-disable-with="Publishing..">Publish all</button>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3892,4 +3892,29 @@ describe('formatter', () => {
     const expected = [`<script src="aaa => 1">`, `    const a = 1;`, `    const b = 2;`, `</script>`, ``].join('\n');
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('keep html attribute indentation', async () => {
+    const content = [
+      `@component('some.file')`,
+      `    <div>`,
+      `        <input type="text" an-object="{`,
+      `            'Some error': 1,`,
+      `        }" />`,
+      `    </div>`,
+      `@endcomponent`,
+    ].join('\n');
+
+    const expected = [
+      `@component('some.file')`,
+      `    <div>`,
+      `        <input type="text" an-object="{`,
+      `            'Some error': 1,`,
+      `        }" />`,
+      `    </div>`,
+      `@endcomponent`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });


### PR DESCRIPTION
- fix: 🐛 multiline html attribute keep indenting
- test: 💍 fix test cases to follow current behaviour

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds protection for html attributes that is not formatted yet.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/86

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Multiline html attribute keep indenting.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
