### PR TITLE
fix: 🐛 raw string in custom directive results syntax error

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3917,4 +3917,11 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('custom directive with raw string parameter should be work', async () => {
+    const content = [`@popper(This should be work)`].join('\n');
+    const expected = [`@popper(This should be work)`, ``].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1647,13 +1647,17 @@ export default class Formatter {
         const indent = detectIndent(matchedLine[0]);
 
         const matched = `${this.customDirectives[p1]}`;
-        return _.replace(matched, /(@[a-zA-z0-9\-_]+)(.*)/gis, (_match2: string, p2: string, p3: string) => {
-          const formatted = util
-            .formatRawStringAsPhp(`func${p3}`)
-            .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-            .trim()
-            .substring(4);
-          return `${p2}${this.indentComponentAttribute(indent.indent, formatted)}`;
+        return _.replace(matched, /(@[a-zA-z0-9\-_]+)(.*)/gis, (match2: string, p2: string, p3: string) => {
+          try {
+            const formatted = util
+              .formatRawStringAsPhp(`func${p3}`)
+              .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+              .trim()
+              .substring(4);
+            return `${p2}${this.indentComponentAttribute(indent.indent, formatted)}`;
+          } catch (error) {
+            return `${match2}`;
+          }
         });
       },
     );
@@ -1670,13 +1674,17 @@ export default class Formatter {
         const indent = detectIndent(matchedLine[0]);
         const matched = `${this.customDirectives[p1]}`;
 
-        return _.replace(matched, /(@[a-zA-z0-9\-_]+)(.*)/gis, (_match2: string, p3: string, p4: string) => {
-          const formatted = util
-            .formatRawStringAsPhp(`func${p4}`, this.wrapLineLength, false)
-            .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-            .trim()
-            .substring(4);
-          return `${p3}${this.indentComponentAttribute(indent.indent, formatted)}`;
+        return _.replace(matched, /(@[a-zA-z0-9\-_]+)(.*)/gis, (match2: string, p3: string, p4: string) => {
+          try {
+            const formatted = util
+              .formatRawStringAsPhp(`func${p4}`, this.wrapLineLength, false)
+              .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+              .trim()
+              .substring(4);
+            return `${p3}${this.indentComponentAttribute(indent.indent, formatted)}`;
+          } catch (error) {
+            return `${match2}`;
+          }
         });
       },
     );


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/443

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/443

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: https://github.com/shufo/vscode-blade-formatter/issues/443

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Blade directive treat entire parameter as string.
e.g. `@popper(This works)` will pass string parameter `'This works'` to directive function.

```php
Blade::directive('popper', function (string $text) {
    // $text => 'This works'
    return $text;
});

// even if string contains `,`, directive will pass entire parameter as string
@popper(This works, 2nd args)

Blade::directive('popper', function (string $text) {
    // $text => 'This works, 2nd args'
    return $text;
});

```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
