### PR TITLE
fix: 🐛 script tag attributes are unindented when multi-lined

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3924,4 +3924,11 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('script tag indentation with multiline attribute', async () => {
+    const content = [`<script`, `src="{{ asset('js/chat.js') }}"`, `defer`, `></script>`].join('\n');
+    const expected = [`<script`, `    src="{{ asset('js/chat.js') }}"`, `    defer`, `></script>`, ``].join('\n');
+
+    await util.doubleFormatCheck(content, expected, { wrapAttributes: 'force-expand-multiline' });
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1619,7 +1619,6 @@ export default class Formatter {
             indent_size: util.optional(this.options).indentSize || 4,
             wrap_line_length: util.optional(this.options).wrapLineLength || 120,
             wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
-            wrap_attributes_indent_size: indent.amount,
             end_with_newline: false,
             templating: ['php'],
           };


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/440

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/440

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/440

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Multi-lined script tag should be indent even if wrapping option specified

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
