### PR TITLE
fix: 🐛 sometimes equal symbols cause formatting to get stuck

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3931,4 +3931,58 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected, { wrapAttributes: 'force-expand-multiline' });
   });
+
+  test('it should not be stuck even if equal character exists https://github.com/shufo/vscode-blade-formatter/issues/474', async () => {
+    const content = [
+      `<div>`,
+      `<table>`,
+      `<tr>`,
+      `@if ($potRR == true)`,
+      `                                <td wire:key='{{ $this->getRandomStr() }}'>`,
+      `                                    -`,
+      `                                </td>`,
+      `                            @else`,
+      `                                @if ($tasks->isNotEmpty())`,
+      `                                @foreach ($tasks->where('id', '=', 1) as $task)`,
+      `                                <p>dd</p>`,
+      `                                @endforeach`,
+      `                                @else`,
+      `                                    <td wire:key='{{ $this->getRandomStr() }}'`,
+      `                                        wire:click='openAssignTaskModal({{ $pot->id }})'>`,
+      `                                        -`,
+      `                                    </td>`,
+      `                                @endif`,
+      `                            @endif`,
+      `</tr>`,
+      `</table>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    <table>`,
+      `        <tr>`,
+      `            @if ($potRR == true)`,
+      `                <td wire:key='{{ $this->getRandomStr() }}'>`,
+      `                    -`,
+      `                </td>`,
+      `            @else`,
+      `                @if ($tasks->isNotEmpty())`,
+      `                    @foreach ($tasks->where('id', '=', 1) as $task)`,
+      `                        <p>dd</p>`,
+      `                    @endforeach`,
+      `                @else`,
+      `                    <td wire:key='{{ $this->getRandomStr() }}' wire:click='openAssignTaskModal({{ $pot->id }})'>`,
+      `                        -`,
+      `                    </td>`,
+      `                @endif`,
+      `            @endif`,
+      `        </tr>`,
+      `    </table>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -712,7 +712,7 @@ export default class Formatter {
   async preserveHtmlAttributes(content: any) {
     return _.replace(
       content,
-      /(?<=<[\w]*?[\s].*?)[\w\-\_]*=(["']).*?(?<!\\)\1(?=.*?(?<!=)>)/gms,
+      /(?<=<[\w]*?[\s].*?)[\w\-\_\:]+?=(["']).*?(?<!\\)\1(?=.*?(?<!=)>)/gms,
       (match: string) => `${this.storeHtmlAttribute(match)}`,
     );
   }


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/474

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/474

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/474

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Regular expressions are causing unintended matching and causing stuck.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
