### PR TITLE
fix: indentation removed when raw blade brace is multi-lined

### DIFF
--- a/__tests__/fixtures/formatted.edit.blade.php
+++ b/__tests__/fixtures/formatted.edit.blade.php
@@ -9,7 +9,12 @@
                 <div></div>
                 <p>@lang('user.edit')</p>
             </div>
-            {!! Form::model($user, ['route' => ['frontend.user.user.update', $user['id']], 'method' => 'put', 'class' => 'form-horizontal', 'role' => 'form']) !!}
+            {!! Form::model($user, [
+                'route' => ['frontend.user.user.update', $user['id']],
+                'method' => 'put',
+                'class' => 'form-horizontal',
+                'role' => 'form',
+            ]) !!}
             <ul class="pf-user-form">
                 <li>
                     <p>{!! Form::label('parent_id', __('user.parent')) !!}</p>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -3985,4 +3985,65 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('raw blade brace losts indentation https://github.com/shufo/vscode-blade-formatter/issues/474', async () => {
+    const content = [
+      `                        <div class="row">`,
+      `                            <div class="col-12 col-sm-8 mb-2">`,
+      ``,
+      `                            </div>`,
+      `                            <div class="col-12 col-sm-4">`,
+      `                                {!! Form::button(trans('forms.save-changes'), [`,
+      `    'class' => 'btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save',`,
+      `    'type' => 'button',`,
+      `    'data-toggle' => 'modal',`,
+      `    'data-target' => '#confirmSave',`,
+      `    'data-title' => trans('modals.edit_user__modal_text_confirm_title'),`,
+      `    'data-message' => trans('modals.edit_user__modal_text_confirm_message'),`,
+      `]) !!}`,
+      `                            </div>`,
+      `                        </div>`,
+    ].join('\n');
+
+    const expected = [
+      `                        <div class="row">`,
+      `                            <div class="col-12 col-sm-8 mb-2">`,
+      ``,
+      `                            </div>`,
+      `                            <div class="col-12 col-sm-4">`,
+      `                                {!! Form::button(trans('forms.save-changes'), [`,
+      `                                    'class' => 'btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save',`,
+      `                                    'type' => 'button',`,
+      `                                    'data-toggle' => 'modal',`,
+      `                                    'data-target' => '#confirmSave',`,
+      `                                    'data-title' => trans('modals.edit_user__modal_text_confirm_title'),`,
+      `                                    'data-message' => trans('modals.edit_user__modal_text_confirm_message'),`,
+      `                                ]) !!}`,
+      `                            </div>`,
+      `                        </div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('Long raw blade brace line should be formatted into multiple lines', async () => {
+    const content = [
+      `{!! Form::button(trans('forms.save-changes'), [    'class' => 'btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save',    'type' => 'button',    'data-toggle' => 'modal',    'data-target' => '#confirmSave',    'data-title' => trans('modals.edit_user__modal_text_confirm_title'),    'data-message' => trans('modals.edit_user__modal_text_confirm_message'),]) !!}`,
+    ].join('\n');
+
+    const expected = [
+      `{!! Form::button(trans('forms.save-changes'), [`,
+      `    'class' => 'btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save',`,
+      `    'type' => 'button',`,
+      `    'data-toggle' => 'modal',`,
+      `    'data-target' => '#confirmSave',`,
+      `    'data-title' => trans('modals.edit_user__modal_text_confirm_title'),`,
+      `    'data-message' => trans('modals.edit_user__modal_text_confirm_message'),`,
+      `]) !!}`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1437,18 +1437,22 @@ export default class Formatter {
         res,
         new RegExp(`${this.getRawBladeBracePlaceholder('(\\d+)')}`, 'gms'),
         (_match: any, p1: any) => {
+          const placeholder = this.getRawBladeBracePlaceholder(p1);
+          const matchedLine = content.match(new RegExp(`^(.*?)${placeholder}`, 'gmi')) ?? [''];
+          const indent = detectIndent(matchedLine[0]);
           const bladeBrace = this.rawBladeBraces[p1];
 
           if (bladeBrace.trim() === '') {
             return `{!!${bladeBrace}!!}`;
           }
 
-          return `{!! ${util
-            .formatRawStringAsPhp(bladeBrace)
-            .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-            .trim()
-            // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
-            .trimRight('\n')} !!}`;
+          return this.indentRawPhpBlock(
+            indent,
+            `{!! ${util
+              .formatRawStringAsPhp(bladeBrace, this.wrapLineLength)
+              .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+              .trim()} !!}`,
+          );
         },
       ),
     );


### PR DESCRIPTION
- fix: 🐛 indentation removed when raw blade brace is multi-lined
- test: 💍 fix test case to follow current behaviour
- test: 💍 add test for raw blade braces

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/489

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/489

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Multi-lined raw blade brace should keep its indentation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
