### PR TITLE
fix: 🐛 nested condition inserts unexpected comma

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4046,4 +4046,51 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('nested condition', async () => {
+    const content = [
+      `@if (count( auth("     (  )   ")->user()   ->currentXY->shopsXY()) > 1)`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+      `@if (`,
+      ``,
+      ``,
+      `foo(count( auth("     (  )   ")->user()   ->currentXY->shopsXY()) > 1`,
+      ``,
+      ``,
+      `))`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+      `@if (count(auth()->user()->currentXY->shopsXY()) > 1)`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+    ].join('\n');
+
+    const expected = [
+      `@if (count(auth('     (  )   ')->user()->currentXY->shopsXY()) > 1)`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+      `@if (foo(count(auth('     (  )   ')->user()->currentXY->shopsXY()) > 1))`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+      `@if (count(auth()->user()->currentXY->shopsXY()) > 1)`,
+      `    <span class="ml-24">Test</span>`,
+      `@else`,
+      `    <span class="ml-16">Test</span>`,
+      `@endif`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1484,8 +1484,10 @@ export default class Formatter {
         return this.indentComponentAttribute(
           indent.indent,
           util
-            .formatRawStringAsPhp(matched)
+            .formatRawStringAsPhp(matched, this.wrapLineLength, true)
             .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+            .replace(/(?<!(['"]).*)(?<=\()[\n\s]+?(?=\w)/gms, '')
+            .replace(/,[\n\s]*\)/gs, ')')
             .trimEnd(),
         );
       }),


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/491

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/491

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The prettier php plugin using in this formatter inserts comma at end of parentheses unexpectedly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests