### PR TITLE
refactor: 💡 do not preserve unnecessary spaces in brace braces

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4093,4 +4093,47 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('do not preserve unnecessary spaces in blade braces', async () => {
+    const content = [
+      // escaped brade braces
+      `{{}}`,
+      `{{                      }}`,
+      `{{    `,
+      `      `,
+      `   }}`,
+      `{{`,
+      ``,
+      `auth()->user()->some() }}`,
+      `<p>{{                                                                                                          auth()->user()->some() }}</p>`,
+      // raw blade braces
+      `{!!!!}`,
+      `{!!                      !!}`,
+      `{!!    `,
+      `      `,
+      `   !!}`,
+      `{!!`,
+      ``,
+      `auth()->user()->some() !!}`,
+      `<p>{!!                                                                                                          auth()->user()->some() !!}</p>`,
+    ].join('\n');
+
+    const expected = [
+      // escaped brade braces
+      `{{}}`,
+      `{{ }}`,
+      `{{ }}`,
+      `{{ auth()->user()->some() }}`,
+      `<p>{{ auth()->user()->some() }}</p>`,
+      // raw blade braces
+      `{!!!!}`,
+      `{!! !!}`,
+      `{!! !!}`,
+      `{!! auth()->user()->some() !!}`,
+      `<p>{!! auth()->user()->some() !!}</p>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -662,11 +662,37 @@ export default class Formatter {
   }
 
   async preserveBladeBrace(content: any) {
-    return _.replace(content, /\{\{(.*?)\}\}/gs, (_match: any, p1: any) => this.storeBladeBrace(p1, p1.length));
+    return _.replace(content, /\{\{(.*?)\}\}/gs, (_match: any, p1: any) => {
+      // if content is blank
+      if (p1 === '') {
+        return this.storeBladeBrace(p1, p1.length);
+      }
+
+      // preserve a space if content contains only space, tab, or new line character
+      if (!/\S/.test(p1)) {
+        return this.storeBladeBrace(' ', ' '.length);
+      }
+
+      // any other content
+      return this.storeBladeBrace(p1.trim(), p1.trim().length);
+    });
   }
 
   async preserveRawBladeBrace(content: any) {
-    return _.replace(content, /\{!!(.*?)!!\}/gs, (_match: any, p1: any) => this.storeRawBladeBrace(p1));
+    return _.replace(content, /\{!!(.*?)!!\}/gs, (_match: any, p1: any) => {
+      // if content is blank
+      if (p1 === '') {
+        return this.storeRawBladeBrace(p1);
+      }
+
+      // preserve a space if content contains only space, tab, or new line character
+      if (!/\S/.test(p1)) {
+        return this.storeRawBladeBrace(' ');
+      }
+
+      // any other content
+      return this.storeRawBladeBrace(p1.trim());
+    });
   }
 
   async preserveConditions(content: any) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR refactor brace braces preservation behaviour.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently a blade brace that includes a space will be preserved including the extra space, which may lead to unexpected behavior when formatting.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
