### PR TITLE
fix: 🐛 as keyword breaks line if calling method

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4136,4 +4136,14 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@foreach directive with nested method', async () => {
+    const content = [`@foreach (auth()->user()->currentxy->shops() as $shop)`, `foo`, `@endforeach`].join('\n');
+
+    const expected = [`@foreach (auth()->user()->currentxy->shops() as $shop)`, `    foo`, `@endforeach`, ``].join(
+      '\n',
+    );
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,7 +134,8 @@ export async function prettifyPhpContentWithUnescapedTags(content: any) {
             /<\?php\s(.*?)(\s*?)\((.*?)\);*\s\?>\n/gs,
             (match2: any, j1: any, j2: any, j3: any) => `@${j1.trim()}${j2}(${j3.trim()})`,
           )
-          .replace(/([\n\s]*)->([\n\s]*)/gs, '->'),
+          .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+          .replace(/(?:\n\s*)* as(?= (?:&{0,1}\$[\w]+|list|\[\$[\w]+))/g, ' as'),
       ),
     )
     .then((res) => formatStringAsPhp(res));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/501

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/501

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unexpected line break occur if given variabe to foreach is calling method from object

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
