### PR TITLE
fix: 🐛 unexpected format results when script tag type is not js

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4188,6 +4188,7 @@ describe('formatter', () => {
       `        </div>`,
       `    </script>`,
       `@endsection`,
+      ``,
     ].join('\n');
 
     await util.doubleFormatCheck(content, expected);

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4146,4 +4146,50 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('script tag type with not js code', async () => {
+    const content = [
+      `@section('section')`,
+      `    <script type="text/template" id="test">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `    <script id="test" type="text/template">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `    <script id="test"`,
+      `        type="text/template">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `@endsection`,
+    ].join('\n');
+
+    const expected = [
+      `@section('section')`,
+      `    <script type="text/template" id="test">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `    <script id="test" type="text/template">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `    <script id="test"`,
+      `        type="text/template">`,
+      `        <div>`,
+      `            Test`,
+      `        </div>`,
+      `    </script>`,
+      `@endsection`,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -404,8 +404,13 @@ export default class Formatter {
   preserveBladeDirectivesInScripts(content: any) {
     return _.replace(content, /(?<=<script[^>]*?(?<!=)>)(.*?)(?=<\/script>)/gis, (match: string) => {
       const targetTokens = [...indentStartTokens, ...inlineFunctionTokens];
+
       if (new RegExp(targetTokens.join('|'), 'gmi').test(match) === false) {
-        return match.trim();
+        if (/^[\s\n]+$/.test(match)) {
+          return match.trim();
+        }
+
+        return match;
       }
 
       const inlineFunctionDirectives = inlineFunctionTokens.join('|');
@@ -1643,6 +1648,15 @@ export default class Formatter {
         new RegExp(`${this.getScriptPlaceholder('(\\d+)')}`, 'gim'),
         (_match: any, p1: number) => {
           const script = this.scripts[p1];
+
+          // do nothing if type of script tag is not JS
+          const scriptTagAttrs = script.match(/<script[^>]*?type=(["'])(.*?)\1/);
+          const typeIsNotJavaScript = scriptTagAttrs && scriptTagAttrs[2] !== 'text/javascript';
+
+          if (typeIsNotJavaScript) {
+            return script;
+          }
+
           const placeholder = this.getScriptPlaceholder(p1);
           const matchedLine = content.match(new RegExp(`^(.*?)${placeholder}`, 'gmi')) ?? [''];
           const indent = detectIndent(matchedLine[0]);


### PR DESCRIPTION
✅ Closes: #666

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #666

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #666

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently script tag with not js code will break its format.
So format as JS code only when `type="text/javascript"` or type is not specified, otherwise do nothing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
