### PR TITLE
fix: 🐛 escaped quote in raw php directive breaks indentation

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4193,4 +4193,39 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('escaped quote in raw php directive #669', async () => {
+    const content = [
+      `    @php`,
+      `        if ($condition1) {`,
+      `            $var1 = '...';`,
+      `                         $var2 = '...';`,
+      `        } elseif ($condition2) {`,
+      `            $var1 = '...';`,
+      `            $var2 = 'I have a \\' in me';`,
+      `        } else {`,
+      `            $var1 = '...';`,
+      `            $var2 = '...';`,
+      `        }`,
+      `    @endphp`,
+    ].join('\n');
+
+    const expected = [
+      `    @php`,
+      `        if ($condition1) {`,
+      `            $var1 = '...';`,
+      `            $var2 = '...';`,
+      `        } elseif ($condition2) {`,
+      `            $var1 = '...';`,
+      `            $var2 = 'I have a \\' in me';`,
+      `        } else {`,
+      `            $var1 = '...';`,
+      `            $var2 = '...';`,
+      `        }`,
+      `    @endphp`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -781,7 +781,7 @@ export default class Formatter {
   }
 
   preserveStringLiteralInPhp(content: any) {
-    return _.replace(content, /['"].*?['"]/gms, (match: string) => {
+    return _.replace(content, /('(?:[^\\']+|\\.)*'|"(?:[^\\"]+|\\.)*")/g, (match: string) => {
       return `${this.storeStringLiteralInPhp(match)}`;
     });
   }


### PR DESCRIPTION
✅ Closes: #669

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #669

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #669

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

see #669

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
