### PR TITLE
feat: improve CLI output

### DIFF
--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           yarn install
           yarn build
+          yarn run -s bin --help
           yarn run -s bin __tests__/fixtures/index.blade.php
         env:
           CI: true

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import * as cmd from './support/cmd';
 import * as util from './support/util';
 import { assertFormatted, assertNotFormatted } from './support/assertion';
+import { version } from '../package.json';
 
 describe('The blade formatter CLI', () => {
   test.concurrent('should print the help', async function () {
@@ -485,5 +486,18 @@ describe('The blade formatter CLI', () => {
     const input = 'custom_directives.blade.php';
     const target = 'formatted.custom_directives.blade.php';
     await util.checkIfTemplateIsFormattedTwice(input, target);
+  });
+
+  test.concurrent('unknown option passed', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), ['--unknown', 'foo']);
+
+    expect(cmdResult).toContain('error: Unknown argument: unknown');
+    expect(cmdResult).toContain('For more information try --help');
+  });
+
+  test.concurrent('help shows current version', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), ['--help']);
+
+    expect(cmdResult).toContain(version);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,9 +13,7 @@ export default async function cli() {
   // @ts-ignore
   const parsed = await yargs(hideBin(process.argv))
     .usage(
-      `${chalk.green(
-        `blade-formatter`,
-      )} ${version}\nAn opinionated blade template formatter for Laravel. \n\n ${chalk.yellow(
+      `${chalk.green(name)} ${version}\nAn opinionated blade template formatter for Laravel. \n\n ${chalk.yellow(
         `Usage:`,
       )} $0 [options] [file glob | ...]`,
     )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,14 @@ export default async function cli() {
     })
     .help('h')
     .alias('h', 'help')
+    .strictOptions()
+    .fail(function (msg, err, yargs) {
+      if (err) throw err; // preserve stack
+      process.stdout.write(`${chalk.red(`error: `)}${msg}\n\n`);
+      process.stdout.write(`${chalk.yellow(`Usage: `)} ${name} [options] [file glob | ...]\n\n`);
+      process.stdout.write(`For more information try ${chalk.green(`--help`)}\n`);
+      process.exit(1);
+    })
     .epilog(`Copyright Shuhei Hayashibara 2022\nFor more information, see https://github.com/shufo/blade-formatter`);
 
   // @ts-ignore

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ export default async function cli() {
     .help('h')
     .alias('h', 'help')
     .strictOptions()
-    .fail(function (msg, err, yargs) {
+    .fail(function (msg, err) {
       if (err) throw err; // preserve stack
       process.stdout.write(`${chalk.red(`error: `)}${msg}\n\n`);
       process.stdout.write(`${chalk.yellow(`Usage: `)} ${name} [options] [file glob | ...]\n\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,7 @@ export default async function cli() {
     .option('wrap-attributes', {
       alias: 'wrap-atts',
       type: 'string',
-      description: 'The way to wrap attributes',
+      description: `The way to wrap attributes.\n[auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]`,
       default: 'auto',
     })
     .option('sort-tailwindcss-classes', {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ export default async function cli() {
     })
     .help('h')
     .alias('h', 'help')
-    .epilog('Copyright Shuhei Hayashibara 2019');
+    .epilog(`Copyright Shuhei Hayashibara 2022\nFor more information, see https://github.com/shufo/blade-formatter`);
 
   // @ts-ignore
   // eslint-disable-next-line

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,24 @@
 import yargs from 'yargs';
 import concat from 'concat-stream';
 import { loadWASM } from 'vscode-oniguruma';
+import chalk from 'chalk';
 
 import { promises as fs } from 'fs';
 
 import { hideBin } from 'yargs/helpers';
 import { BladeFormatter } from './main';
+import { name, version } from '../package.json';
 
 export default async function cli() {
   // @ts-ignore
   const parsed = await yargs(hideBin(process.argv))
-    .usage('Usage: $0 [options] [file glob | ...]')
+    .usage(
+      `${chalk.green(
+        `blade-formatter`,
+      )} ${version}\nAn opinionated blade template formatter for Laravel. \n\n ${chalk.yellow(
+        `Usage:`,
+      )} $0 [options] [file glob | ...]`,
+    )
     .example('$0 "resources/views/**/*.blade.php" --write', 'Format all files in views directory')
     .option('check-formatted', {
       alias: 'c',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "@types/jest"],
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR improves CLI outputs.

- help option displays the name and version of the tool and URL to the repository

```bash
 $  blade-formatter --help
blade-formatter 1.26.17
An opinionated blade template formatter for Laravel.

Usage: blade-formatter [options] [file glob | ...]

```

- When a non-existent option or other option is passed, explicitly stating that the option does not exist.

```bash
 $  ./node_modules/.bin/blade-formatter test.blade.php --unknwon
error: Unknown argument: unknwon

Usage:  blade-formatter [options] [file glob | ...]

For more information try --help
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When I looked at other CLI tools, I thought the above things were missing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
