### PR TITLE
fix: 🐛 tab indent is not used in inline directive

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4284,4 +4284,57 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected, { sortHtmlAttributes: 'idiomatic' });
   });
+
+  test('it should use tab for indent inside inline directive', async () => {
+    const content = [
+      `<div>`,
+      `    <div>`,
+      `        <div @class([`,
+      `            'some class',`,
+      `            'some other class',`,
+      `            'another class',`,
+      `            'some class',`,
+      `            'some other class',`,
+      `            'another class',`,
+      `        ])></div>`,
+      `    </div>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `	<div>`,
+      `		<div @class([`,
+      `			'some class',`,
+      `			'some other class',`,
+      `			'another class',`,
+      `			'some class',`,
+      `			'some other class',`,
+      `			'another class',`,
+      `		])></div>`,
+      `	</div>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected, { useTabs: true, indentSize: 1 });
+
+    const expected2 = [
+      `<div>`,
+      `		<div>`,
+      `				<div @class([`,
+      `						'some class',`,
+      `						'some other class',`,
+      `						'another class',`,
+      `						'some class',`,
+      `						'some other class',`,
+      `						'another class',`,
+      `				])></div>`,
+      `		</div>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected2, { useTabs: true, indentSize: 2 });
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1583,11 +1583,15 @@ export default class Formatter {
                   wrapLength = this.wrapLineLength - `func`.length - p1.length - indent.amount;
                 }
 
-                const inside = util
+                let inside = util
                   .formatRawStringAsPhp(`func(${p4})`, wrapLength, true)
                   .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
                   .replace(/,(\s*?\))/gis, (_match5, p5) => p5)
                   .trim();
+
+                if (this.options.useTabs || false) {
+                  inside = _.replace(inside, new RegExp(`(?<=^ *)    `, 'gm'), '\t'.repeat(this.indentSize));
+                }
 
                 if (this.isInline(inside)) {
                   return `${this.indentRawPhpBlock(indent, `${inside}`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes tab indent behaviour in inline directive.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/424

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
