### PR TITLE
fix: 🐛 syntax error on chained method

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4392,4 +4392,21 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected2, { useTabs: true, indentSize: 2 });
   });
+
+  test('unless directive with arrowed method', async () => {
+    const content = [
+      `@unless  (auth()->user()->hasVerifiedEmail())`,
+      `  <p>Please check and verify your email to access the system</p>`,
+      `@endunless`,
+    ].join('\n');
+
+    const expected = [
+      `@unless(auth()->user()->hasVerifiedEmail())`,
+      `    <p>Please check and verify your email to access the system</p>`,
+      `@endunless`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected, { sortHtmlAttributes: 'idiomatic' });
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -135,6 +135,7 @@ export async function prettifyPhpContentWithUnescapedTags(content: any) {
             (match2: any, j1: any, j2: any, j3: any) => `@${j1.trim()}${j2}(${j3.trim()})`,
           )
           .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+          .replace(/,\)$/, ')')
           .replace(/(?:\n\s*)* as(?= (?:&{0,1}\$[\w]+|list|\[\$[\w]+))/g, ' as'),
       ),
     )


### PR DESCRIPTION
✅ Closes: #686

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes #686

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #686

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

prettier plugin-php puts a comma before the last parenthesis when the method is chained.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
