### PR TITLE
fix: 🐛 elseif statement in script tag gets unexpected format

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4409,4 +4409,34 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected, { sortHtmlAttributes: 'idiomatic' });
   });
+
+  test('elseif statement in script tag', async () => {
+    const content = [
+      `<script>`,
+      `@if (session()->has('success'))`,
+      `//do something`,
+      `@elseif (session()->has('error'))`,
+      `//do something`,
+      `@elseif`,
+      `($something)`,
+      `//do something`,
+      `@endif`,
+      `</script>`,
+    ].join('\n');
+
+    const expected = [
+      `<script>`,
+      `    @if (session()->has('success'))`,
+      `        //do something`,
+      `    @elseif (session()->has('error'))`,
+      `        //do something`,
+      `    @elseif ($something)`,
+      `        //do something`,
+      `    @endif`,
+      `</script>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1344,9 +1344,18 @@ export default class Formatter {
       // restore else
       formatted = _.replace(
         formatted,
-        new RegExp(`} \\/\\* (?:${this.getBladeDirectiveInScriptPlaceholder('(\\d+)')}) \\*\\/ {`, 'gis'),
-        (_match: any, p1: any) => {
-          return `${this.directivesInScript[p1].trim()}`;
+        new RegExp(
+          `} \\/\\* (?:${this.getBladeDirectiveInScriptPlaceholder(
+            '(\\d+)',
+          )}) \\*\\/ {(\\s*?\\(___directive_condition_\\d+___\\))?`,
+          'gim',
+        ),
+        (_match: any, p1: number, p2: string) => {
+          if (_.isUndefined(p2)) {
+            return `${this.directivesInScript[p1].trim()}`;
+          }
+
+          return `${this.directivesInScript[p1].trim()} ${(p2 ?? '').trim()}`;
         },
       );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/536

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/536

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently elseif statement in script tag is formatted with line break.

## How Has This Been Tested?

see tests
