### PR TITLE
fix: 🐛 inline directive issue with tailwind class sorting

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4439,4 +4439,23 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('inline directive with tailwindcss class sort', async () => {
+    const content = [
+      `<div class="@auth bg-10 @endauth relative h-10 w-10"></div>`,
+      `<div class="relative h-10 w-10 @auth bg-10 @endauth "></div>`,
+      `<div class="@auth @endauth relative h-10 w-10"></div>`,
+      `<div class="@auth     @endauth relative h-10 w-10"></div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div class="@auth bg-10 @endauth relative h-10 w-10"></div>`,
+      `<div class="@auth bg-10 @endauth relative h-10 w-10"></div>`,
+      `<div class="@auth @endauth relative h-10 w-10"></div>`,
+      `<div class="@auth  @endauth relative h-10 w-10"></div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected, { sortTailwindcssClasses: true });
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4446,6 +4446,7 @@ describe('formatter', () => {
       `<div class="relative h-10 w-10 @auth bg-10 @endauth "></div>`,
       `<div class="@auth @endauth relative h-10 w-10"></div>`,
       `<div class="@auth     @endauth relative h-10 w-10"></div>`,
+      `<div class="@if (true) bg-neutral-100 @endif relative h-10 w-10"></div>`,
     ].join('\n');
 
     const expected = [
@@ -4453,9 +4454,55 @@ describe('formatter', () => {
       `<div class="@auth bg-10 @endauth relative h-10 w-10"></div>`,
       `<div class="@auth @endauth relative h-10 w-10"></div>`,
       `<div class="@auth  @endauth relative h-10 w-10"></div>`,
+      `<div class="@if (true) bg-neutral-100 @endif relative h-10 w-10"></div>`,
       ``,
     ].join('\n');
 
     await util.doubleFormatCheck(content, expected, { sortTailwindcssClasses: true });
+  });
+
+  test('line breaked inline directive with tailwindcss class sort', async () => {
+    const content = [
+      `<input`,
+      `    @unless($hasMask())`,
+      ``,
+      `        {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"`,
+      `         type="{{ $getType() }}"`,
+      `    @else`,
+      `        x-data="textInputFormComponent({`,
+      `            {{ $hasMask() ? "getMaskOptionsUsing: (IMask) => ({$getJsonMaskConfiguration()})," : null }}`,
+      `            state: $wire.{{ $isLazy()`,
+      `                ? 'entangle(' . $getStatePath() . ').defer'`,
+      `                : $applyStateBindingModifiers('entangle(' . $getStatePath() . ')') }},`,
+      `           })"`,
+      `        type="text"`,
+      `        wire:ignore`,
+      `        @if ($isLazy()) x-on:blur="$wire.$refresh" @endif`,
+      `        {{ $getExtraAlpineAttributeBag() }}`,
+      `    @endunless />`,
+    ].join('\n');
+
+    const expected = [
+      `<input`,
+      `    @unless($hasMask())`,
+      ``,
+      `        {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"`,
+      `         type="{{ $getType() }}"`,
+      `    @else`,
+      `        x-data="textInputFormComponent({`,
+      `            {{ $hasMask() ? "getMaskOptionsUsing: (IMask) => ({$getJsonMaskConfiguration()})," : null }}`,
+      `            state: $wire.{{ $isLazy()`,
+      `                ? 'entangle(' . $getStatePath() . ').defer'`,
+      `                : $applyStateBindingModifiers('entangle(' . $getStatePath() . ')') }},`,
+      `           })"`,
+      `        type="text"`,
+      `        wire:ignore`,
+      `        @if ($isLazy()) x-on:blur="$wire.$refresh" @endif`,
+      `        {{ $getExtraAlpineAttributeBag() }}`,
+      `    @endunless />`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected, { sortHtmlAttributes: 'alphabetical' });
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -376,13 +376,27 @@ export default class Formatter {
     const regex = new RegExp(
       `(<[\\w\\-\\_]+?[^>]*?)${directivePrefix}(${indentStartTokensWithoutPrefix.join(
         '|',
-      )})(\\s*?)(\\([^)]*?\\))((?:(?!@end\\2).)+)(@end\\2|@endif)(.*?/*>)`,
+      )})(\\s*?)?(\\([^)]*?\\))?((?:(?!@end\\2).)+)(@end\\2|@endif)(.*?/*>)`,
       'gims',
     );
     const replaced = _.replace(
       content,
       regex,
       (_match: string, p1: string, p2: string, p3: string, p4: string, p5: string, p6: string, p7: string) => {
+        if (p3 === undefined && p4 === undefined) {
+          return `${p1}${this.storeInlineDirective(`${directivePrefix}${p2.trim()}${p5.trim()} ${p6.trim()}`)}${p7}`;
+        }
+        if (p3 === undefined) {
+          return `${p1}${this.storeInlineDirective(
+            `${directivePrefix}${p2.trim()}${p4.trim()}${p5}${p6.trim()}`,
+          )}${p7}`;
+        }
+        if (p4 === undefined) {
+          return `${p1}${this.storeInlineDirective(
+            `${directivePrefix}${p2.trim()}${p3}${p5.trim()} ${p6.trim()}`,
+          )}${p7}`;
+        }
+
         return `${p1}${this.storeInlineDirective(
           `${directivePrefix}${p2.trim()}${p3}${p4.trim()} ${p5.trim()} ${p6.trim()}`,
         )}${p7}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/525.
Inlined directive lost its content if tailwindcss class sorting is enabled.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/525

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

tailwind css class sorting conflicts inline directive formatting.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
