### PR TITLE
fix: 🐛 invalid quote type when html tag used in php directive

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4505,4 +4505,25 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected, { sortHtmlAttributes: 'alphabetical' });
   });
+
+  test('html tag in raw php block', async () => {
+    const content = [
+      `@php`,
+      `$icon = "<i class='fa fa-check'></i>";`,
+      `$icon    = "<i class=\"fa fa-check\"></i>";`,
+      `$icon       = '<i class="fa fa-check"></i>';`,
+      `@endphp`,
+    ].join('\n');
+
+    const expected = [
+      `@php`,
+      `$icon = "<i class='fa fa-check'></i>";`,
+      `$icon = "<i class=\"fa fa-check\"></i>";`,
+      `$icon = '<i class="fa fa-check"></i>';`,
+      `@endphp`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4510,7 +4510,7 @@ describe('formatter', () => {
     const content = [
       `@php`,
       `$icon = "<i class='fa fa-check'></i>";`,
-      `$icon    = "<i class=\"fa fa-check\"></i>";`,
+      `$icon    = "<i class=\\"fa fa-check\\"></i>";`,
       `$icon       = '<i class="fa fa-check"></i>';`,
       `@endphp`,
     ].join('\n');
@@ -4518,7 +4518,7 @@ describe('formatter', () => {
     const expected = [
       `@php`,
       `$icon = "<i class='fa fa-check'></i>";`,
-      `$icon = "<i class=\"fa fa-check\"></i>";`,
+      `$icon = "<i class=\\"fa fa-check\\"></i>";`,
       `$icon = '<i class="fa fa-check"></i>';`,
       `@endphp`,
       ``,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -181,12 +181,14 @@ export default class Formatter {
       .then((target) => this.preserveComponentAttribute(target))
       .then((target) => this.preserveShorthandBinding(target))
       .then((target) => this.sortHtmlAttributes(target))
+      .then((target) => this.preservePhpBlock(target))
       .then((target) => this.preserveHtmlAttributes(target))
       .then((target) => this.preserveHtmlTags(target))
       .then((target) => this.formatAsHtml(target))
       .then((target) => this.formatAsBlade(target))
       .then((target) => this.restoreHtmlTags(target))
       .then((target) => this.restoreHtmlAttributes(target))
+      .then((target) => this.restorePhpBlock(target))
       .then((target) => this.restoreShorthandBinding(target))
       .then((target) => this.restoreComponentAttribute(target))
       .then((target) => this.restoreXData(target))
@@ -221,11 +223,9 @@ export default class Formatter {
     };
 
     const promise = new Promise((resolve) => resolve(data))
-      .then((content) => this.preservePhpBlock(content))
       .then((content) => util.preserveDirectives(content))
       .then((preserved) => beautify.html_beautify(preserved, options))
-      .then((content) => util.revertDirectives(content))
-      .then((content) => this.restorePhpBlock(content));
+      .then((content) => util.revertDirectives(content));
 
     return Promise.resolve(promise);
   }


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/prettier-plugin-blade/issues/138

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/138

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/138

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Incorrect escaping of quote when using html tags within `@php` ~ `@endphp` directive

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
