### PR TITLE
feat:  add option for tailwindcss configuration 

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -12,38 +11,38 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-    - uses: actions/cache@v3
-      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-    - name: npm install
-      run: |
-        yarn install
-      env:
-        CI: true
-    - name: linting
-      run: |
-        yarn run lint
-        yarn run check_formatted
-      env:
-        CI: true
-    - name: yarn run test --runInBand
-      run: |
-        yarn test
-      env:
-        CI: true
-    - uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: npm install
+        run: |
+          yarn install
+        env:
+          CI: true
+      - name: linting
+        run: |
+          yarn run lint
+          yarn run check_formatted
+        env:
+          CI: true
+      - name: yarn run test --runInBand
+        run: |
+          yarn test
+        env:
+          CI: true
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
 ## Options
 
 |                             option |                                                                                                                      description | default |
-| ---------------------------------: | -------------------------------------------------------------------------------------------------------------------------------: | ------: |
+| ---------------------------------: | :------------------------------------------------------------------------------------------------------------------------------- | :------ |
 |          `--check-formatted`, `-c` |                                          Only check files are formatted or not. Exit with exit code 1 if files are not formatted |   false |
 |                   `--write`, `--w` |                                                                                                                    Write to file |   false |
 |                     `--diff`, `-d` |                                                                                                                 Show differences |   false |

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -570,7 +570,7 @@ describe('The blade formatter CLI', () => {
     const startTime = performance.now();
     await util.checkIfTemplateIsFormattedTwice(input, target);
     const endTime = performance.now();
-    expect(endTime - startTime).toBeLessThan(7500);
+    expect(endTime - startTime).toBeLessThan(10000);
   });
 
   test.concurrent('data url', async () => {

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -581,4 +581,65 @@ describe('The blade formatter CLI', () => {
     const endTime = performance.now();
     expect(endTime - startTime).toBeLessThan(5000);
   });
+
+  test.concurrent('respect tailwind.config.js automatically', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'tailwind', 'index.blade.php'),
+      '--sort-tailwindcss-classes',
+    ]);
+
+    const formatted = fs.readFileSync(path.resolve('__tests__', 'fixtures', 'tailwind', 'formatted.index.blade.php'));
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('specify tailwind.config.js path (absolute path)', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'tailwind', 'index.blade.php'),
+      '--sort-tailwindcss-classes',
+      '--tailwindcss-config-path',
+      path.resolve('__tests__', 'fixtures', 'tailwind', 'tailwind.config.example.js'),
+    ]);
+
+    const formatted = fs.readFileSync(path.resolve('__tests__', 'fixtures', 'tailwind', 'formatted.index.blade.php'));
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('specify tailwind.config.js path (relative path)', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'tailwind', 'index.blade.php'),
+      '--sort-tailwindcss-classes',
+      '--tailwindcss-config-path',
+      '__tests__/fixtures/tailwind/tailwind.config.example.js',
+    ]);
+
+    const formatted = fs.readFileSync(path.resolve('__tests__', 'fixtures', 'tailwind', 'formatted.index.blade.php'));
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('unresolvable tailwind config', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'tailwind', 'index.blade.php'),
+      '--sort-tailwindcss-classes',
+      '--tailwindcss-config-path',
+      '__tests__/fixtures/tailwind/tailwind.config.unresolvable.js',
+    ]);
+
+    expect(cmdResult).toContain("Cannot find module 'tailwindcss/unresolvable");
+  });
+
+  test.concurrent('runtime config test (tailwind)', async () => {
+    // automatically recognize tailwind config from .bladeformatter.json
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'tailwind', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'tailwind', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -570,7 +570,7 @@ describe('The blade formatter CLI', () => {
     const startTime = performance.now();
     await util.checkIfTemplateIsFormattedTwice(input, target);
     const endTime = performance.now();
-    expect(endTime - startTime).toBeLessThan(5000);
+    expect(endTime - startTime).toBeLessThan(7500);
   });
 
   test.concurrent('data url', async () => {
@@ -579,7 +579,7 @@ describe('The blade formatter CLI', () => {
     const startTime = performance.now();
     await util.checkIfTemplateIsFormattedTwice(input, target);
     const endTime = performance.now();
-    expect(endTime - startTime).toBeLessThan(5000);
+    expect(endTime - startTime).toBeLessThan(7500);
   });
 
   test.concurrent('respect tailwind.config.js automatically', async () => {

--- a/__tests__/fixtures/runtimeConfig/tailwind/.bladeformatterrc.json
+++ b/__tests__/fixtures/runtimeConfig/tailwind/.bladeformatterrc.json
@@ -1,0 +1,4 @@
+{
+  "sortTailwindcssClasses": true,
+  "tailwindcssConfigPath": "./tailwind.config.example.js"
+}

--- a/__tests__/fixtures/runtimeConfig/tailwind/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/tailwind/formatted.index.blade.php
@@ -1,0 +1,3 @@
+<div class="col-start-2 col-end-11 md:col-end-12 xl:col-end-10 xxxl:col-end-8">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/__tests__/fixtures/runtimeConfig/tailwind/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/tailwind/index.blade.php
@@ -1,0 +1,3 @@
+<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/__tests__/fixtures/runtimeConfig/tailwind/tailwind.config.example.js
+++ b/__tests__/fixtures/runtimeConfig/tailwind/tailwind.config.example.js
@@ -1,0 +1,15 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
+module.exports = {
+  theme: {
+    screens: {
+      sm: '0',
+      md: '834px',
+      lg: '1024px',
+      xl: '1200px',
+      xxl: '1440px',
+      xxxl: '1900px',
+      ...defaultTheme.screens,
+    },
+  },
+};

--- a/__tests__/fixtures/tailwind/formatted.index.blade.php
+++ b/__tests__/fixtures/tailwind/formatted.index.blade.php
@@ -1,0 +1,3 @@
+<div class="col-start-2 col-end-11 md:col-end-12 xl:col-end-10 xxxl:col-end-8">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/__tests__/fixtures/tailwind/index.blade.php
+++ b/__tests__/fixtures/tailwind/index.blade.php
@@ -1,0 +1,3 @@
+<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/__tests__/fixtures/tailwind/tailwind.config.example.js
+++ b/__tests__/fixtures/tailwind/tailwind.config.example.js
@@ -1,0 +1,15 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
+module.exports = {
+  theme: {
+    screens: {
+      sm: '0',
+      md: '834px',
+      lg: '1024px',
+      xl: '1200px',
+      xxl: '1440px',
+      xxxl: '1900px',
+      ...defaultTheme.screens,
+    },
+  },
+};

--- a/__tests__/fixtures/tailwind/tailwind.config.js
+++ b/__tests__/fixtures/tailwind/tailwind.config.js
@@ -1,0 +1,15 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
+module.exports = {
+  theme: {
+    screens: {
+      sm: '0',
+      md: '834px',
+      lg: '1024px',
+      xl: '1200px',
+      xxl: '1440px',
+      xxxl: '1900px',
+      ...defaultTheme.screens,
+    },
+  },
+};

--- a/__tests__/fixtures/tailwind/tailwind.config.unresolvable.js
+++ b/__tests__/fixtures/tailwind/tailwind.config.unresolvable.js
@@ -1,0 +1,15 @@
+const defaultTheme = require('tailwindcss/unresolvable');
+
+module.exports = {
+  theme: {
+    screens: {
+      sm: '0',
+      md: '834px',
+      lg: '1024px',
+      xl: '1200px',
+      xxl: '1440px',
+      xxxl: '1900px',
+      ...defaultTheme.screens,
+    },
+  },
+};

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4526,4 +4526,43 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('tailwind config path option', async () => {
+    const content = [
+      `<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">`,
+      `    <h1 class="text-white">Random Stuff</h1>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div class="col-start-2 col-end-11 md:col-end-12 xl:col-end-10 xxxl:col-end-8">`,
+      `    <h1 class="text-white">Random Stuff</h1>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    const configPath = path.resolve('__tests__', 'fixtures', 'tailwind', 'tailwind.config.example.js');
+    await util.doubleFormatCheck(content, expected, {
+      sortTailwindcssClasses: true,
+      tailwindcssConfigPath: configPath,
+    });
+  });
+
+  test('tailwind config object option', async () => {
+    const content = [
+      `<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">`,
+      `    <h1 class="text-white">Random Stuff</h1>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div class="col-start-2 col-end-11 md:col-end-12 xl:col-end-10 xxxl:col-end-8">`,
+      `    <h1 class="text-white">Random Stuff</h1>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    const config = require(path.resolve('__tests__', 'fixtures', 'tailwind', 'tailwind.config.example.js'));
+    await util.doubleFormatCheck(content, expected, { sortTailwindcssClasses: true, tailwindcssConfig: config });
+  });
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,10 @@
-codecov: 
+codecov:
   require_ci_to_pass: no
   github_checks:
     annotations: false
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%
+        base: auto

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash": "^4.17.19",
     "php-parser": "3.1.0",
     "prettier": "^2.2.0",
+    "tailwindcss": "^3.1.8",
     "vscode-oniguruma": "1.6.2",
     "vscode-textmate": "^7.0.1",
     "xregexp": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@prettier/plugin-php": "^0.19.0",
-    "@shufo/tailwindcss-class-sorter": "^1.0.6",
+    "@shufo/tailwindcss-class-sorter": "^1.0.7",
     "aigle": "^1.14.1",
     "ajv": "^8.9.0",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@prettier/plugin-php": "^0.19.0",
-    "@shufo/tailwindcss-class-sorter": "^1.0.7",
+    "@shufo/tailwindcss-class-sorter": "^1.0.8",
     "aigle": "^1.14.1",
     "ajv": "^8.9.0",
     "chalk": "^4.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,12 @@ export default async function cli() {
       description: 'Sort tailwindcss classes',
       default: false,
     })
+    .option('tailwindcss-config-path', {
+      alias: ['tailwindcssConfigPath'],
+      type: 'string',
+      description: 'Specify path of tailwind config',
+      default: null,
+    })
     .option('sort-html-attributes', {
       alias: 'sort-attributes',
       type: 'string',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -240,6 +240,16 @@ export default class Formatter {
         return p2;
       }
 
+      if (this.options.tailwindcssConfigPath) {
+        const options = { tailwindConfigPath: this.options.tailwindcssConfigPath };
+        return sortClasses(p2, options);
+      }
+
+      if (this.options.tailwindcssConfig) {
+        const options = { tailwindConfig: this.options.tailwindcssConfig };
+        return sortClasses(p2, options);
+      }
+
       return sortClasses(p2);
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,8 @@ class BladeFormatter {
 
   static targetFiles: any;
 
+  runtimeConfigPath: string | null;
+
   runtimeConfigCache: RuntimeConfig;
 
   constructor(options: FormatterOption & CLIOption = {}, paths: any = []) {
@@ -79,6 +81,7 @@ class BladeFormatter {
     this.ignoreFile = '';
     this.fulFillFiles = [];
     this.targetFiles = [];
+    this.runtimeConfigPath = options.runtimeConfigPath ?? null;
     this.runtimeConfigCache = {};
   }
 
@@ -144,7 +147,14 @@ class BladeFormatter {
     let configFilePath: string | null | undefined;
 
     if (this.options.tailwindcssConfigPath) {
-      configFilePath = nodepath.resolve(this.options.tailwindcssConfigPath);
+      if (this.runtimeConfigPath) {
+        const workingDir = nodepath.dirname(this.runtimeConfigPath);
+        configFilePath = nodepath.resolve(workingDir, this.options.tailwindcssConfigPath);
+      } else if (nodepath.isAbsolute(this.options.tailwindcssConfigPath)) {
+        configFilePath = nodepath.resolve(this.options.tailwindcssConfigPath);
+      } else {
+        configFilePath = nodepath.resolve(this.options.tailwindcssConfigPath);
+      }
     } else {
       // lookup tailwind config
       const workingDir = nodepath.dirname(filePath);
@@ -174,6 +184,8 @@ class BladeFormatter {
     if (_.isNull(configFile)) {
       return;
     }
+
+    this.runtimeConfigPath = configFile;
 
     try {
       const options = await readRuntimeConfig(configFile);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,9 @@ import glob from 'glob';
 import nodeutil from 'util';
 import _ from 'lodash';
 import findConfig from 'find-config';
+import { Config as TailwindConfig } from 'tailwindcss/types/config';
 import Formatter from './formatter';
 import * as util from './util';
-import { Config as TailwindConfig } from 'tailwindcss/types/config';
 import {
   findRuntimeConfig,
   readRuntimeConfig,

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -23,6 +23,7 @@ export interface RuntimeConfig {
   endWithNewline?: boolean;
   useTabs?: boolean;
   sortTailwindcssClasses?: boolean;
+  tailwindcssConfigPath?: string;
   sortHtmlAttributes?: SortHtmlAttributes;
   noMultipleEmptyLines?: boolean;
 }
@@ -72,6 +73,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
       endWithNewline: { type: 'boolean', nullable: true },
       useTabs: { type: 'boolean', nullable: true },
       sortTailwindcssClasses: { type: 'boolean', nullable: true },
+      tailwindcssConfigPath: { type: 'string', nullable: true },
       sortHtmlAttributes: {
         type: 'string',
         enum: ['none', 'alphabetical', 'code-guide', 'idiomatic', 'vuejs'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,10 +1613,10 @@
     mem "^8.0.0"
     php-parser "3.1.0"
 
-"@shufo/tailwindcss-class-sorter@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@shufo/tailwindcss-class-sorter/-/tailwindcss-class-sorter-1.0.7.tgz#c7fd035bac198642104d74c843f1a879f11df4cb"
-  integrity sha512-WctRYBKc4Qk+KFpE9BZh6mLg4DveevA0VhFjaK8JI5Pv9rTbDQLu7900sop77L1rFeD1zfTtJuOCs+ADzom+wA==
+"@shufo/tailwindcss-class-sorter@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@shufo/tailwindcss-class-sorter/-/tailwindcss-class-sorter-1.0.8.tgz#27b04fc743825fb1c14b9b9edafd1dcc6b32cbd0"
+  integrity sha512-m+vOaTJJPiJ8ZJGUBzCRVLPxgHu+yztgIR9ck8M2IgudN0feku6x1uGn193tVgDbbeTBPjTY3PFN1DAzf862jA==
   dependencies:
     escalade "^3.1.1"
     object-hash "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,14 +1613,14 @@
     mem "^8.0.0"
     php-parser "3.1.0"
 
-"@shufo/tailwindcss-class-sorter@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@shufo/tailwindcss-class-sorter/-/tailwindcss-class-sorter-1.0.6.tgz#3133ed1243c64a133a7eef88441bcd165cbb03c6"
-  integrity sha512-iVJ+0e3vK3SFmvdfOVAD8+goBw+IOnIlyMaQ61SWi28EQYqNyS0mRb5OXeiatV2J2MzS7OyVPuly7QxUe9/oBg==
+"@shufo/tailwindcss-class-sorter@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@shufo/tailwindcss-class-sorter/-/tailwindcss-class-sorter-1.0.7.tgz#c7fd035bac198642104d74c843f1a879f11df4cb"
+  integrity sha512-WctRYBKc4Qk+KFpE9BZh6mLg4DveevA0VhFjaK8JI5Pv9rTbDQLu7900sop77L1rFeD1zfTtJuOCs+ADzom+wA==
   dependencies:
     escalade "^3.1.1"
     object-hash "^3.0.0"
-    tailwindcss "^3.0.23"
+    tailwindcss "^3.1.8"
 
 "@sinclair/typebox@^0.23.3":
   version "0.23.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,11 +1812,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.6.tgz#cc1589c9ee853b389e67e8fb4384e0f250a139b9"
   integrity sha512-+XBAjfZmmivILUzO0HwBJoYkAyyySSLg5KCGBDFLomJo0sV6szvVLAf4ANZZ0pfWzgEds5KmGLG9D5hfEqOhaA==
 
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
 "@types/prettier@^2.1.5":
   version "2.4.2"
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz"
@@ -1977,7 +1972,7 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-node@^1.6.1:
+acorn-node@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
   integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
@@ -2135,10 +2130,10 @@ arg@^4.1.0:
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-arg@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.1.tgz#eb0c9a8f77786cad2af8ff2b862899842d7b6adb"
-  integrity sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==
+arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2758,17 +2753,6 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.8.tgz#f2157793b58719196ccf9673cc14f3683adc0957"
   integrity sha512-bOxbZIy9S5n4OVH63XaLVXZ49QKicjowDx/UELyJ68vxfCRpYsbyh/WNZNfEfAk+ekA8vSjt+gCDpvh672bc3w==
 
-cosmiconfig@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
-
 create-jest-runner@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/create-jest-runner/-/create-jest-runner-0.5.3.tgz#1387e2ce70b08e4c989ae55f677005b64f9ba97b"
@@ -2901,14 +2885,14 @@ detect-newline@^3.0.0:
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detective@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"
-  integrity sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
+detective@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.1.tgz#6af01eeda11015acb0e73f933242b70f24f91034"
+  integrity sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==
   dependencies:
-    acorn-node "^1.6.1"
+    acorn-node "^1.8.2"
     defined "^1.0.0"
-    minimist "^1.1.1"
+    minimist "^1.2.6"
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -4124,6 +4108,13 @@ is-core-module@^2.8.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -4901,10 +4892,15 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lilconfig@2.0.4, lilconfig@^2.0.4:
+lilconfig@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
   integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
+
+lilconfig@^2.0.5, lilconfig@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
+  integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -5166,7 +5162,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -5194,10 +5190,10 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -5282,11 +5278,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-hash@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
-  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-hash@^3.0.0:
   version "3.0.0"
@@ -5461,7 +5452,7 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-json@^5.0.0, parse-json@^5.2.0:
+parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -5536,6 +5527,11 @@ picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+
 pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
@@ -5572,6 +5568,15 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-import@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-14.1.0.tgz#a7333ffe32f0b8795303ee9e40215dac922781f0"
+  integrity sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
 postcss-js@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"
@@ -5579,12 +5584,12 @@ postcss-js@^4.0.0:
   dependencies:
     camelcase-css "^2.0.1"
 
-postcss-load-config@^3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.3.tgz#21935b2c43b9a86e6581a576ca7ee1bde2bd1d23"
-  integrity sha512-5EYgaM9auHGtO//ljHH+v/aC/TQ5LHXtL7bQajNAUBKUVKiYE8rYpFms7+V26D9FncaGe2zwCoPQsFKb5zF/Hw==
+postcss-load-config@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
   dependencies:
-    lilconfig "^2.0.4"
+    lilconfig "^2.0.5"
     yaml "^1.10.2"
 
 postcss-nested@5.0.6:
@@ -5594,7 +5599,15 @@ postcss-nested@5.0.6:
   dependencies:
     postcss-selector-parser "^6.0.6"
 
-postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
+postcss-selector-parser@^6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.0.6:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
   integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
@@ -5602,17 +5615,17 @@ postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.6:
-  version "8.4.7"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.7.tgz#f99862069ec4541de386bf57f5660a6c7a0875a8"
-  integrity sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==
+postcss@^8.4.14:
+  version "8.4.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
+  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
   dependencies:
-    nanoid "^3.3.1"
+    nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -5702,6 +5715,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
+  dependencies:
+    pify "^2.3.0"
 
 readable-stream@^3.0.2:
   version "3.6.0"
@@ -5852,7 +5872,16 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.14.2, resolve@^1.22.0:
+resolve@^1.1.7, resolve@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.14.2:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -6357,32 +6386,33 @@ table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tailwindcss@^3.0.23:
-  version "3.0.23"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.23.tgz#c620521d53a289650872a66adfcb4129d2200d10"
-  integrity sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==
+tailwindcss@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.1.8.tgz#4f8520550d67a835d32f2f4021580f9fddb7b741"
+  integrity sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==
   dependencies:
-    arg "^5.0.1"
-    chalk "^4.1.2"
+    arg "^5.0.2"
     chokidar "^3.5.3"
     color-name "^1.1.4"
-    cosmiconfig "^7.0.1"
-    detective "^5.2.0"
+    detective "^5.2.1"
     didyoumean "^1.2.2"
     dlv "^1.1.3"
     fast-glob "^3.2.11"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
+    lilconfig "^2.0.6"
     normalize-path "^3.0.0"
-    object-hash "^2.2.0"
-    postcss "^8.4.6"
+    object-hash "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.14"
+    postcss-import "^14.1.0"
     postcss-js "^4.0.0"
-    postcss-load-config "^3.1.0"
+    postcss-load-config "^3.1.4"
     postcss-nested "5.0.6"
-    postcss-selector-parser "^6.0.9"
+    postcss-selector-parser "^6.0.10"
     postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
-    resolve "^1.22.0"
+    resolve "^1.22.1"
 
 tapable@^2.2.0:
   version "2.2.1"
@@ -6883,7 +6913,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.0, yaml@^1.10.2:
+yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds 

- `tailwindcssConfigPath`, `tailwindcssConfig` option for formatter.\n
- `--tailwindcss-config-path` for CLI option.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/554

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
tailwind config `tailwind.config.js` should respect when `sortTailwindcssClasses` option is enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests