### PR TITLE
fix: 🐛 timeout occur when unclosed quote exists in php block

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4573,4 +4573,23 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('it should not timeout even if there is a quote in php expression', async () => {
+    const content = [
+      `@php`,
+      `// if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs`,
+      `$breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;`,
+      `@endphp`,
+    ].join('\n');
+
+    const expected = [
+      `@php`,
+      `// if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs`,
+      `$breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;`,
+      `@endphp`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -819,7 +819,7 @@ export default class Formatter {
   }
 
   preserveStringLiteralInPhp(content: any) {
-    return _.replace(content, /('(?:[^\\']+|\\.)*'|"(?:[^\\"]+|\\.)*")/g, (match: string) => {
+    return _.replace(content, /(\'([^\\']|\\.)*?\'|\"([^\\']|\\.)*?\")/gm, (match: string) => {
       return `${this.storeStringLiteralInPhp(match)}`;
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/563

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/563

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
