### PR TITLE
fix: 🐛 json directive is not indented when it is multi-line

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4592,4 +4592,31 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('inline @json directive', async () => {
+    const content = [
+      `@section('footer')`,
+      `    <script>`,
+      `        Object.assign(lang, @json([`,
+      `            'name' => __('name'),`,
+      `            'current' => __('current'),`,
+      `        ]));`,
+      `    </script>`,
+      `@endsection`,
+    ].join('\n');
+
+    const expected = [
+      `@section('footer')`,
+      `    <script>`,
+      `        Object.assign(lang, @json([`,
+      `            'name' => __('name'),`,
+      `            'current' => __('current'),`,
+      `        ]));`,
+      `    </script>`,
+      `@endsection`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -29,6 +29,7 @@ import {
   indentStartTokensWithoutPrefix,
   unbalancedStartTokens,
   cssAtRuleTokens,
+  inlinePhpDirectives,
 } from './indent';
 import { nestedParenthesisRegex } from './regex';
 import { SortHtmlAttributes } from './runtimeConfig';
@@ -1600,10 +1601,13 @@ export default class Formatter {
               .trimRight('\n')}`;
           }
 
-          if (/(@button|@class|@include|@disabled|@checked)/gi.test(matched)) {
+          if (new RegExp(inlinePhpDirectives.join('|'), 'gi').test(matched)) {
             const formatted = _.replace(
               matched,
-              /(?<=@(button|class|include|disabled|checked).*?\()(.*)(?=\))/gis,
+              new RegExp(
+                `(?<=@(${_.map(inlinePhpDirectives, (token) => token.substring(1)).join('|')}).*?\\()(.*)(?=\\))`,
+                'gis',
+              ),
               (match2: any, p3: any, p4: any) => {
                 let wrapLength = this.wrapLineLength;
 

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -116,6 +116,8 @@ export const phpKeywordStartTokens = ['@forelse', '@if', '@for', '@foreach', '@w
 
 export const phpKeywordEndTokens = ['@endforelse', '@endif', '@endforeach', '@endfor', '@endwhile', '@break'];
 
+export const inlinePhpDirectives = ['@button', '@class', '@include', '@disabled', '@checked', '@json'];
+
 export const inlineFunctionTokens = [
   '@set',
   '@json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/565

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/565

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should indent the inside of json directives even if they are multiple lines.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
