### PR TITLE
feat: option to disable php syntax check

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,30 +170,29 @@ $ blade-formatter -c -d resources/**/*.blade.php
 ## Options
 
 ```bash
-Options:
-      --version                                           Show version number  [boolean]
-  -c, --check-formatted                                   Only checks files are formatted or not  [boolean] [default: false]
-  -w, --write                                             Write to file  [boolean] [default: false]
-  -d, --diff                                              Show diffs  [boolean] [default: false]
-  -e, --end-with-newline                                  End output with newline  [boolean] [default: true]
-  -i, --indent-size                                       Indentation size  [default: 4]
-      --wrap-line-length, --wrap                          The length of line wrap size  [default: 120]
-      --wrap-attributes, --wrap-atts                      The way to wrap attributes.
-                                                          [auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]  [string] [default: "auto"]
-      --sort-tailwindcss-classes, --sort-classes          Sort tailwindcss classes  [boolean] [default: false]
-      --tailwindcss-config-path, --tailwindcssConfigPath  Specify path of tailwind config  [string] [default: null]
-      --sort-html-attributes, --sort-attributes           Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs"] [default: none]
-      --no-multiple-empty-lines                           Merge multiple blank lines into a single blank line  [boolean] [default: false]
-      --no-php-syntax-check                               Disable PHP sytnax checking  [boolean] [default: false]
-  -p, --progress                                          Print progress  [boolean] [default: false]
-      --stdin                                             format code provided on <STDIN>  [boolean] [default: false]
-      --config, --runtimeConfigPath                       Use this configuration, overriding .bladeformatterrc config options if present  [string] [default: null]
-      --ignore-path, --ignoreFilePath                     Specify path of ignore file  [string] [default: null]
-  -h, --help                                              Show help  [boolean]
+  Options:
+      --version                       Show version number  [boolean]
+  -c, --check-formatted               Only checks files are formatted or not  [boolean] [default: false]
+  -w, --write                         Write to file  [boolean] [default: false]
+  -d, --diff                          Show diffs  [boolean] [default: false]
+  -e, --end-with-newline              End output with newline  [boolean] [default: true]
+  -i, --indent-size                   Indentation size  [default: 4]
+      --wrap-line-length, --wrap      The length of line wrap size  [default: 120]
+      --wrap-attributes, --wrap-atts  The way to wrap attributes.
+                                      [auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]  [string] [default: "auto"]
+      --sort-tailwindcss-classes      Sort tailwindcss classes  [boolean] [default: false]
+      --tailwindcss-config-path       Specify path of tailwind config  [string] [default: null]
+      --sort-html-attributes          Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs"] [default: none]
+      --no-multiple-empty-lines       Merge multiple blank lines into a single blank line  [boolean] [default: false]
+      --no-php-syntax-check           Disable PHP sytnax checking  [boolean] [default: false]
+  -p, --progress                      Print progress  [boolean] [default: false]
+      --stdin                         format code provided on <STDIN>  [boolean] [default: false]
+      --config                        Use this configuration, overriding .bladeformatterrc config options if present  [string] [default: null]
+      --ignore-path                   Specify path of ignore file  [string] [default: null]
+  -h, --help                          Show help  [boolean]
 
 Examples:
   blade-formatter "resources/views/**/*.blade.php" --write  Format all files in views directory
-
 ```
 
 ## Configuring blade-formatter

--- a/README.md
+++ b/README.md
@@ -169,21 +169,32 @@ $ blade-formatter -c -d resources/**/*.blade.php
 
 ## Options
 
-|                             option |                                                                                                                      description | default |
-| ---------------------------------: | :------------------------------------------------------------------------------------------------------------------------------- | :------ |
-|          `--check-formatted`, `-c` |                                          Only check files are formatted or not. Exit with exit code 1 if files are not formatted |   false |
-|                   `--write`, `--w` |                                                                                                                    Write to file |   false |
-|                     `--diff`, `-d` |                                                                                                                 Show differences |   false |
-|              `--indent-size`, `-i` |                                                                                                                 Indentation size |       4 |
-|     `--wrap-line-length`, `--wrap` |                                                                                                     The length of line wrap size |     120 |
-| `--wrap-attributes`, `--wrap-atts` | The way to wrap attributes. `[auto\|force\|force-aligned\|force-expand-multiline\|aligned-multiple\|preserve\|preserve-aligned]` |  `auto` |
-| `--sort-tailwindcss-classes`, `--sort-classes` | Sort Tailwindcss classes automatically. This option respects `tailwind.config.js` and sort classes according to settings. |  false |
-| `--sort-html-attributes`, `--sort-attributes` | Sort HTML Attributes in the specified order. `[none\|alphabetical\|code-guide\|idiomatic\|vuejs]` |  `'none'` |
-| `--no-multiple-empty-lines` |  Collapses multiple blank lines into a single blank line | false |
-|         `--end-with-newline`, `-e` |                                                                                                          End output with newline |    true |
-|                          `--stdin` |                                                                                                format code provided on `<STDIN>` |   false |
-|                     `--help`, `-h` |                                                                                                                        Show help |         |
-|                  `--version`, `-v` |                                                                                                                     Show version |         |
+```bash
+Options:
+      --version                                           Show version number  [boolean]
+  -c, --check-formatted                                   Only checks files are formatted or not  [boolean] [default: false]
+  -w, --write                                             Write to file  [boolean] [default: false]
+  -d, --diff                                              Show diffs  [boolean] [default: false]
+  -e, --end-with-newline                                  End output with newline  [boolean] [default: true]
+  -i, --indent-size                                       Indentation size  [default: 4]
+      --wrap-line-length, --wrap                          The length of line wrap size  [default: 120]
+      --wrap-attributes, --wrap-atts                      The way to wrap attributes.
+                                                          [auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]  [string] [default: "auto"]
+      --sort-tailwindcss-classes, --sort-classes          Sort tailwindcss classes  [boolean] [default: false]
+      --tailwindcss-config-path, --tailwindcssConfigPath  Specify path of tailwind config  [string] [default: null]
+      --sort-html-attributes, --sort-attributes           Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs"] [default: none]
+      --no-multiple-empty-lines                           Merge multiple blank lines into a single blank line  [boolean] [default: false]
+      --no-php-syntax-check                               Disable PHP sytnax checking  [boolean] [default: false]
+  -p, --progress                                          Print progress  [boolean] [default: false]
+      --stdin                                             format code provided on <STDIN>  [boolean] [default: false]
+      --config, --runtimeConfigPath                       Use this configuration, overriding .bladeformatterrc config options if present  [string] [default: null]
+      --ignore-path, --ignoreFilePath                     Specify path of ignore file  [string] [default: null]
+  -h, --help                                              Show help  [boolean]
+
+Examples:
+  blade-formatter "resources/views/**/*.blade.php" --write  Format all files in views directory
+
+```
 
 ## Configuring blade-formatter
 
@@ -200,7 +211,8 @@ e.g.
   "useTabs": false,
   "sortTailwindcssClasses": true,
   "sortHtmlAttributes": "none",
-  "noMultipleEmptyLines": false
+  "noMultipleEmptyLines": false,
+  "noPhpSyntaxCheck": false
 }
 ```
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -642,4 +642,28 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent('no php syntax check option from CLI', async () => {
+    // automatically recognize tailwind config from .bladeformatter.json
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'no_php_syntax_check.blade.php'),
+      '--no-php-syntax-check',
+    ]);
+
+    const formatted = fs.readFileSync(path.resolve('__tests__', 'fixtures', 'formatted.no_php_syntax_check.blade.php'));
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('runtime config test (no_php_syntax_check)', async () => {
+    const cmdResult = await cmd.execute(path.resolve('bin', 'blade-formatter'), [
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'noPhpSyntaxCheck', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'noPhpSyntaxCheck', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/fixtures/formatted.no_php_syntax_check.blade.php
+++ b/__tests__/fixtures/formatted.no_php_syntax_check.blade.php
@@ -1,0 +1,1 @@
+{{ 'john' |ucfirst | substr:0,1 }}

--- a/__tests__/fixtures/no_php_syntax_check.blade.php
+++ b/__tests__/fixtures/no_php_syntax_check.blade.php
@@ -1,0 +1,1 @@
+{{'john' |ucfirst | substr:0,1}}

--- a/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/.bladeformatterrc
+++ b/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/.bladeformatterrc
@@ -1,0 +1,3 @@
+{
+  "noPhpSyntaxCheck": true
+}

--- a/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/formatted.index.blade.php
@@ -1,0 +1,6 @@
+{{ 'john' |ucfirst | substr:0,1 }}
+<script>
+    @if (foo)
+        foo
+    @endif
+</script>

--- a/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/noPhpSyntaxCheck/index.blade.php
@@ -1,0 +1,6 @@
+{{'john' |ucfirst | substr:0,1}}
+<script>
+    @if (     foo)
+    foo
+    @endif
+</script>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4677,4 +4677,14 @@ describe('formatter', () => {
     await util.doubleFormatCheck(content, expected);
     await expect(new BladeFormatter().format(content)).resolves.not.toThrow("Can't format blade");
   });
+
+  test('no php syntax check option', async () => {
+    const content = [`{{ 'john' |ucfirst | substr:0,1 }}`, `@if (foo)`, `foo`, `@endif`].join('\n');
+
+    const expected = [`{{ 'john' |ucfirst | substr:0,1 }}`, `@if (foo)`, `    foo`, `@endif`, ``].join('\n');
+
+    const options = { noPhpSyntaxCheck: true };
+    await util.doubleFormatCheck(content, expected, options);
+    await expect(new BladeFormatter(options).format(content)).resolves.not.toThrow('SyntaxError');
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,7 @@ export default async function cli() {
     })
     .option('no-php-syntax-check', {
       type: 'boolean',
-      description: 'Disable PHP sytnax check',
+      description: 'Disable PHP sytnax checking',
       default: false,
     })
     .option('php-syntax-check', {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,17 @@ export default async function cli() {
       hidden: true,
       default: true,
     })
+    .option('no-php-syntax-check', {
+      type: 'boolean',
+      description: 'Disable PHP sytnax check',
+      default: false,
+    })
+    .option('php-syntax-check', {
+      type: 'boolean',
+      description: 'this is a workaround for combine strict && boolean option',
+      hidden: true,
+      default: true,
+    })
     .option('progress', {
       alias: 'p',
       type: 'boolean',
@@ -132,7 +143,10 @@ export default async function cli() {
   const wasm = await fs.readFile(require.resolve('vscode-oniguruma/release/onig.wasm'));
   await loadWASM(wasm.buffer);
 
-  const options = _.set(parsed.argv, 'noMultipleEmptyLines', !parsed.argv.multipleEmptyLines);
+  const options = _.chain(parsed.argv)
+    .set('noMultipleEmptyLines', !parsed.argv.multipleEmptyLines)
+    .set('noPhpSyntaxCheck', !parsed.argv.phpSyntaxCheck)
+    .value();
 
   if (parsed.argv.stdin) {
     await process.stdin.pipe(

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,16 +20,16 @@ import {
 } from './runtimeConfig';
 import FormatError from './errors/formatError';
 
-export interface CLIOption {
+export type CLIOption = {
   write?: boolean;
   diff?: boolean;
   checkFormatted?: boolean;
   progress?: boolean;
   ignoreFilePath?: string;
   runtimeConfigPath?: string;
-}
+};
 
-export interface FormatterOption {
+export type FormatterOption = {
   indentSize?: number;
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
@@ -40,7 +40,9 @@ export interface FormatterOption {
   tailwindcssConfig?: TailwindConfig;
   sortHtmlAttributes?: SortHtmlAttributes;
   noMultipleEmptyLines?: boolean;
-}
+};
+
+export type BladeFormatterOption = CLIOption & FormatterOption;
 
 class BladeFormatter {
   diffs: any;
@@ -69,7 +71,7 @@ class BladeFormatter {
 
   runtimeConfigCache: RuntimeConfig;
 
-  constructor(options: FormatterOption & CLIOption = {}, paths: any = []) {
+  constructor(options: BladeFormatterOption = {}, paths: any = []) {
     this.currentTargetPath = '.';
     this.paths = paths;
     this.options = options;
@@ -85,7 +87,7 @@ class BladeFormatter {
     this.runtimeConfigCache = {};
   }
 
-  async format(content: any, opts = {}) {
+  async format(content: any, opts: BladeFormatterOption = {}) {
     this.options = this.options || opts;
     const target = nodepath.resolve(process.cwd(), 'target');
     await this.readIgnoreFile(target);

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ export type FormatterOption = {
   tailwindcssConfig?: TailwindConfig;
   sortHtmlAttributes?: SortHtmlAttributes;
   noMultipleEmptyLines?: boolean;
+  noPhpSyntaxCheck?: boolean;
 };
 
 export type BladeFormatterOption = CLIOption & FormatterOption;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -26,6 +26,7 @@ export interface RuntimeConfig {
   tailwindcssConfigPath?: string;
   sortHtmlAttributes?: SortHtmlAttributes;
   noMultipleEmptyLines?: boolean;
+  noPhpSyntaxCheck?: boolean;
 }
 
 const defaultConfigNames = ['.bladeformatterrc.json', '.bladeformatterrc'];
@@ -80,6 +81,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
         nullable: true,
       },
       noMultipleEmptyLines: { type: 'boolean', nullable: true },
+      noPhpSyntaxCheck: { type: 'boolean', nullable: true },
     },
     additionalProperties: true,
   };

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,29 +37,73 @@ export function splitByLines(content: any) {
   return content.split(/\r\n|\n|\r/);
 }
 
-export function formatStringAsPhp(content: any) {
-  return prettier.format(content.replace(/\n$/, ''), {
-    parser: 'php',
-    printWidth: 1000,
-    singleQuote: true,
-    // @ts-ignore
-    phpVersion: '8.0',
-    plugins: [phpPlugin],
-  });
+export type FormatPhpOption = {
+  noPhpSyntaxCheck?: boolean;
+  printWidth?: number;
+  trailingCommaPHP?: boolean;
+  phpVersion?: string;
+  singleQuote?: boolean;
+};
+
+export const printWidthForInline = 1000;
+
+const defaultFormatPhpOption = {
+  noPhpSyntaxCheck: false,
+  printWidth: printWidthForInline,
+  trailingCommaPHP: true,
+  phpVersion: '8.1',
+  singleQuote: true,
+};
+
+export function formatStringAsPhp(content: any, options: FormatPhpOption = {}) {
+  options = {
+    ...defaultFormatPhpOption,
+    ...options,
+  };
+
+  try {
+    return prettier.format(content.replace(/\n$/, ''), {
+      parser: 'php',
+      printWidth: 1000,
+      singleQuote: options.singleQuote,
+      // @ts-ignore
+      phpVersion: options.phpVersion,
+      trailingCommaPHP: options.trailingCommaPHP,
+      plugins: [phpPlugin],
+    });
+  } catch (error) {
+    if (options.noPhpSyntaxCheck === false) {
+      throw error;
+    }
+    return content;
+  }
 }
 
-export function formatRawStringAsPhp(content: any, printWidth = 1000, trailingCommaPHP = true) {
-  return prettier
-    .format(`<?php echo ${content} ?>`, {
-      parser: 'php',
-      printWidth,
-      singleQuote: true,
-      // @ts-ignore
-      phpVersion: '8.0',
-      trailingCommaPHP,
-      plugins: [phpPlugin],
-    })
-    .replace(/<\?php echo (.*)?\?>/gs, (match: any, p1: any) => p1.trim().replace(/;\s*$/, ''));
+export function formatRawStringAsPhp(content: string, options: FormatPhpOption = {}) {
+  options = {
+    ...defaultFormatPhpOption,
+    ...options,
+  };
+
+  try {
+    return prettier
+      .format(`<?php echo ${content} ?>`, {
+        parser: 'php',
+        printWidth: options.printWidth,
+        singleQuote: options.singleQuote,
+        // @ts-ignore
+        phpVersion: options.phpVersion,
+        trailingCommaPHP: options.trailingCommaPHP,
+        plugins: [phpPlugin],
+      })
+      .replace(/<\?php echo (.*)?\?>/gs, (match: any, p1: any) => p1.trim().replace(/;\s*$/, ''));
+  } catch (error) {
+    if (options.noPhpSyntaxCheck === false) {
+      throw error;
+    }
+
+    return content;
+  }
 }
 
 export function getArgumentsCount(expression: any) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,10 +55,10 @@ const defaultFormatPhpOption = {
   singleQuote: true,
 };
 
-export function formatStringAsPhp(content: any, options: FormatPhpOption = {}) {
-  options = {
+export function formatStringAsPhp(content: any, params: FormatPhpOption = {}) {
+  const options = {
     ...defaultFormatPhpOption,
-    ...options,
+    ...params,
   };
 
   try {
@@ -79,10 +79,10 @@ export function formatStringAsPhp(content: any, options: FormatPhpOption = {}) {
   }
 }
 
-export function formatRawStringAsPhp(content: string, options: FormatPhpOption = {}) {
-  options = {
+export function formatRawStringAsPhp(content: string, params: FormatPhpOption = {}) {
+  const options = {
     ...defaultFormatPhpOption,
-    ...options,
+    ...params,
   };
 
   try {


### PR DESCRIPTION
- refactor: 💡 add union type BladeFormatterOption
- feat: 🎸 add option `--no-php-syntax-check`
- test: 💍 add tests for no php syntax check option
- refactor: 💡 change the name of parameter

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds feature to disable php syntax check.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- closes: #691

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Blade expression allows arbitaly string to its arguments like:

```blade
{{ 'john' | ucfirst | substr:0,1 }}
```

Because blade treat arguments as literal strings.  
So it's up to directive implementation.

Blade Formatter normally treats the representation in the Blade's Directive as PHP because it's formattable.
But this behavior cannot be support the directives that implementing custom syntax.
So I implemented this.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
