### PR TITLE
fix: indent inside of php directive on top level

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4713,4 +4713,57 @@ describe('formatter', () => {
     const options = { noPhpSyntaxCheck: true };
     await util.doubleFormatCheck(content, expected, options);
   });
+
+  test('indent inside @php directive', async () => {
+    const content = [
+      `@php`,
+      `$a = 1;`,
+      `$b = 2;`,
+      `@endphp`,
+      `<div>`,
+      `@php`,
+      `$a = 1;`,
+      `$b = 2;`,
+      `@endphp`,
+      `@php`,
+      `$icon = "<i class='fa fa-check'></i>";`,
+      `$icon = "<i class=\\"fa fa-check\\"></i>";`,
+      `$icon = '<i class="fa fa-check"></i>';`,
+      `@endphp`,
+      `</div>`,
+      `<script>`,
+      `@php`,
+      `$a = 1;`,
+      `$b = 2;`,
+      `@endphp`,
+      `</script>`,
+    ].join('\n');
+
+    const expected = [
+      `@php`,
+      `    $a = 1;`,
+      `    $b = 2;`,
+      `@endphp`,
+      `<div>`,
+      `    @php`,
+      `        $a = 1;`,
+      `        $b = 2;`,
+      `    @endphp`,
+      `    @php`,
+      `        $icon = "<i class='fa fa-check'></i>";`,
+      `        $icon = "<i class=\\"fa fa-check\\"></i>";`,
+      `        $icon = '<i class="fa fa-check"></i>';`,
+      `    @endphp`,
+      `</div>`,
+      `<script>`,
+      `    @php`,
+      `        $a = 1;`,
+      `        $b = 2;`,
+      `    @endphp`,
+      `</script>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4517,9 +4517,9 @@ describe('formatter', () => {
 
     const expected = [
       `@php`,
-      `$icon = "<i class='fa fa-check'></i>";`,
-      `$icon = "<i class=\\"fa fa-check\\"></i>";`,
-      `$icon = '<i class="fa fa-check"></i>';`,
+      `    $icon = "<i class='fa fa-check'></i>";`,
+      `    $icon = "<i class=\\"fa fa-check\\"></i>";`,
+      `    $icon = '<i class="fa fa-check"></i>';`,
       `@endphp`,
       ``,
     ].join('\n');
@@ -4584,8 +4584,8 @@ describe('formatter', () => {
 
     const expected = [
       `@php`,
-      `// if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs`,
-      `$breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;`,
+      `    // if breadcrumbs aren't defined in the CrudController, use the default breadcrumbs`,
+      `    $breadcrumbs = $breadcrumbs ?? $defaultBreadcrumbs;`,
       `@endphp`,
       ``,
     ].join('\n');

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -843,7 +843,7 @@ export default class Formatter {
   }
 
   preserveStringLiteralInPhp(content: any) {
-    return _.replace(content, /(\'([^\\']|\\.)*?\'|\"([^\\']|\\.)*?\")/gm, (match: string) => {
+    return _.replace(content, /(\"([^\\]|\\.)*?\"|\'([^\\]|\\.)*?\')/gm, (match: string) => {
       return `${this.storeStringLiteralInPhp(match)}`;
     });
   }
@@ -1218,10 +1218,6 @@ export default class Formatter {
   }
 
   indentRawBlock(indent: detectIndent.Indent, content: any) {
-    if (_.isEmpty(indent.indent)) {
-      return content;
-    }
-
     if (this.isInline(content)) {
       return `${indent.indent}${content}`;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes behaviour of php directive on top level.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: https://github.com/shufo/vscode-blade-formatter/issues/524

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

At first, I thought it would be better not to indent along PSR-2, but since the blade directive itself is not related PSR-2, I changed this behavior for consistency.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
