### PR TITLE
feat: add option for end of line character(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
   -w, --write                         Write to file  [boolean] [default: false]
   -d, --diff                          Show diffs  [boolean] [default: false]
   -e, --end-with-newline              End output with newline  [boolean] [default: true]
+      --end-of-line                   End of line character(s). [string] [choices: "LF", "CRLF"]
   -i, --indent-size                   Indentation size  [default: 4]
       --wrap-line-length, --wrap      The length of line wrap size  [default: 120]
       --wrap-attributes, --wrap-atts  The way to wrap attributes.
@@ -208,6 +209,7 @@ e.g.
   "wrapAttributes": "auto",
   "wrapLineLength": 120,
   "endWithNewLine": true,
+  "endOfLine": "LF",
   "useTabs": false,
   "sortTailwindcssClasses": true,
   "sortHtmlAttributes": "none",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { loadWASM } from 'vscode-oniguruma';
 import chalk from 'chalk';
 import _ from 'lodash';
 
+import os from "os";
 import { promises as fs } from 'fs';
 
 import { hideBin } from 'yargs/helpers';
@@ -43,6 +44,11 @@ export default async function cli() {
       type: 'boolean',
       description: 'End output with newline',
       default: true,
+    })
+    .option('end-of-line', {
+      type: 'string',
+      description: 'End of line character(s). [LF|CRLF]',
+      default: os.EOL === '\r\n' ? 'CRLF' : 'LF',
     })
     .option('indent-size', {
       alias: 'i',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -119,6 +119,8 @@ export default class Formatter {
 
   defaultPhpFormatOption: util.FormatPhpOption;
 
+  endOfLine: string;
+
   constructor(options: BladeFormatterOption) {
     this.options = {
       ...{
@@ -166,6 +168,7 @@ export default class Formatter {
     this.result = [];
     this.diffs = [];
     this.defaultPhpFormatOption = { noPhpSyntaxCheck: this.options.noPhpSyntaxCheck, printWidth: this.wrapLineLength };
+    this.endOfLine = util.getEndOfLine(util.optional(this.options).endOfLine);
   }
 
   formatContent(content: any) {
@@ -237,6 +240,7 @@ export default class Formatter {
       css: {
         end_with_newline: false,
       },
+      eol: this.endOfLine,
     };
 
     const promise = new Promise((resolve) => resolve(data))
@@ -2112,7 +2116,7 @@ export default class Formatter {
       this.processLine(tokenizeLineResult, originalLine);
     }
 
-    return this.result.join(os.EOL);
+    return this.result.join(this.endOfLine);
   }
 
   processLine(tokenizeLineResult: any, originalLine: any) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import * as util from './util';
 import {
   findRuntimeConfig,
   readRuntimeConfig,
+  EndOfLine,
   RuntimeConfig,
   SortHtmlAttributes,
   WrapAttributes,
@@ -34,6 +35,7 @@ export type FormatterOption = {
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
   endWithNewline?: boolean;
+  endOfLine?: EndOfLine;
   useTabs?: boolean;
   sortTailwindcssClasses?: true;
   tailwindcssConfigPath?: string;
@@ -398,7 +400,7 @@ class BladeFormatter {
       if (this.options.checkFormatted) {
         process.stdout.write(
           '\nAbove file(s) are formattable. Forgot to run formatter? ' +
-            `Use ${chalk.bold('--write')} option to overwrite.\n`,
+          `Use ${chalk.bold('--write')} option to overwrite.\n`,
         );
       }
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -16,11 +16,14 @@ export type WrapAttributes =
 
 export type SortHtmlAttributes = 'none' | 'alphabetical' | 'code-guide' | 'idiomatic' | 'vuejs' | 'custom';
 
+export type EndOfLine = 'LF' | 'CRLF';
+
 export interface RuntimeConfig {
   indentSize?: number;
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
   endWithNewline?: boolean;
+  endOfLine?: EndOfLine;
   useTabs?: boolean;
   sortTailwindcssClasses?: boolean;
   tailwindcssConfigPath?: string;
@@ -73,6 +76,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
         nullable: true,
       },
       endWithNewline: { type: 'boolean', nullable: true },
+      endOfLine: { type: 'string', enum: ['LF', 'CRLF'], nullable: true },
       useTabs: { type: 'boolean', nullable: true },
       sortTailwindcssClasses: { type: 'boolean', nullable: true },
       tailwindcssConfigPath: { type: 'string', nullable: true },

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import _ from 'lodash';
 import fs from 'fs';
+import os from 'os';
 import chalk from 'chalk';
 import prettier from 'prettier/standalone';
 // @ts-ignore
@@ -8,6 +9,7 @@ import phpPlugin from '@prettier/plugin-php/standalone';
 import detectIndent from 'detect-indent';
 import { indentStartTokens, phpKeywordStartTokens, phpKeywordEndTokens } from './indent';
 import { nestedParenthesisRegex } from './regex';
+import { EndOfLine } from './runtimeConfig';
 
 export const optional = (obj: any) => {
   const chain = {
@@ -379,4 +381,15 @@ export function debugLog(...content: any) {
   });
 
   return content;
+}
+
+export function getEndOfLine(endOfLine?: EndOfLine): string {
+  switch (endOfLine) {
+    case 'LF':
+      return '\n';
+    case 'CRLF':
+      return '\r\n';
+    default:
+      return os.EOL;
+  }
 }


### PR DESCRIPTION
Add option for the EOL character.

## Description

<!--- Describe your changes in detail -->
Add a cli (`end-of-line`) and config (`endOfLine`) option to use a specific end of line character or characters. 

By default, if no option is specified, we still use the `os.EOL` character
