### PR TITLE
fix: 🐛 unexpected indent on raw php comment block

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4824,4 +4824,171 @@ describe('formatter', () => {
       endOfLine: 'CRLF',
     });
   });
+
+  test('fix shufo/prettier-plugin-blade#166', async () => {
+    const content = [
+      `@php`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */`,
+      `@endphp`,
+      `<span>{{ $post->title }} by {{ $user->name }}</span>`,
+    ].join('\n');
+
+    const expected = [
+      `@php`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */`,
+      `@endphp`,
+      `<span>{{ $post->title }} by {{ $user->name }}</span>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('raw php comment block', async () => {
+    const content = [
+      `<div>`,
+      `    <?php`,
+      `            /**`,
+      `                * @var \App\Models\User $user`,
+      `            * @var \App\Models\Post $post`,
+      `          */`,
+      `    ?>`,
+      `    <?php`,
+      `    /**`,
+      `            * @var \App\Models\User $user`,
+      `                * @var \App\Models\Post $post`,
+      `           */`,
+      `        /**`,
+      `     * @var \App\Models\User $user`,
+      `                * @var \App\Models\Post $post`,
+      `     */ echo 1;`,
+      `    ?>`,
+      `    <?php`,
+      `        /**`,
+      `     * @var \App\Models\User $user`,
+      `            * @var \App\Models\Post $post`,
+      `     */`,
+      `    ?>`,
+      `    <?php`,
+      `        /**`,
+      `              \App\Models\User $user`,
+      `                 \App\Models\Post $post`,
+      `     */`,
+      `    ?>`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    <?php`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */`,
+      `    ?>`,
+      `    <?php`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */ echo 1;`,
+      `    ?>`,
+      `    <?php`,
+      `    /**`,
+      `     * @var \App\Models\User $user`,
+      `     * @var \App\Models\Post $post`,
+      `     */`,
+      `    ?>`,
+      `    <?php`,
+      `    /**`,
+      `              \App\Models\User $user`,
+      `                 \App\Models\Post $post`,
+      `     */`,
+      `    ?>`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
+  test('php directive comment block', async () => {
+    const content = [
+      `<div>`,
+      `    @php`,
+      `            /**`,
+      `                * @var \App\Models\User $user`,
+      `            * @var \App\Models\Post $post`,
+      `          */`,
+      `    @endphp`,
+      `    @php`,
+      `    /**`,
+      `            * @var \App\Models\User $user`,
+      `                * @var \App\Models\Post $post`,
+      `           */`,
+      `        /**`,
+      `     * @var \App\Models\User $user`,
+      `                * @var \App\Models\Post $post`,
+      `     */ echo 1;`,
+      `    @endphp`,
+      `    @php`,
+      `        /**`,
+      `     * @var \App\Models\User $user`,
+      `            * @var \App\Models\Post $post`,
+      `     */`,
+      `    @endphp`,
+      `    @php`,
+      `    /**`,
+      `              \App\Models\User $user`,
+      `                 \App\Models\Post $post`,
+      `                          */`,
+      `    @endphp`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @php`,
+      `        /**`,
+      `         * @var \App\Models\User $user`,
+      `         * @var \App\Models\Post $post`,
+      `         */`,
+      `    @endphp`,
+      `    @php`,
+      `        /**`,
+      `         * @var \App\Models\User $user`,
+      `         * @var \App\Models\Post $post`,
+      `         */`,
+      `        /**`,
+      `         * @var \App\Models\User $user`,
+      `         * @var \App\Models\Post $post`,
+      `         */ echo 1;`,
+      `    @endphp`,
+      `    @php`,
+      `        /**`,
+      `         * @var \App\Models\User $user`,
+      `         * @var \App\Models\Post $post`,
+      `         */`,
+      `    @endphp`,
+      `    @php`,
+      `        /**`,
+      `              \App\Models\User $user`,
+      `                 \App\Models\Post $post`,
+      `                          */`,
+      `    @endphp`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -52,3 +52,7 @@ export function formatPhpComment(comment: string): string {
 
   return mapped.join('\n');
 }
+
+export default {
+  formatPhpComment,
+};

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,0 +1,54 @@
+/**
+ * Formats php comment
+ *
+ * @param comment
+ * @returns string
+ */
+export function formatPhpComment(comment: string): string {
+  const lines = splitByLines(comment);
+
+  if (!isMultiline(lines)) {
+    return comment;
+  }
+
+  let nonCommentLineExists = false;
+
+  const mapped = lines.map((line: string, row: number) => {
+    if (row === 0) {
+      return line;
+    }
+
+    if (nonCommentLineExists) {
+      return line;
+    }
+
+    if (!isCommentedLine(line)) {
+      nonCommentLineExists = true;
+      return line;
+    }
+
+    const trimmedLine = line.trim();
+
+    return addPrefixToLine(trimmedLine);
+  });
+
+  return mapped.join('\n');
+}
+
+function splitByLines(content: string): Array<string> {
+  return content.split('\n');
+}
+
+function isCommentedLine(line: string): boolean {
+  return line.trim().startsWith('*');
+}
+
+function isMultiline(lines: Array<string>): boolean {
+  return lines.length > 1;
+}
+
+function addPrefixToLine(line: string): string {
+  const prefix = ' ';
+
+  return `${prefix}${line}`;
+}

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,3 +1,21 @@
+function splitByLines(content: string): Array<string> {
+  return content.split('\n');
+}
+
+function isCommentedLine(line: string): boolean {
+  return line.trim().startsWith('*');
+}
+
+function isMultiline(lines: Array<string>): boolean {
+  return lines.length > 1;
+}
+
+function addPrefixToLine(line: string): string {
+  const prefix = ' ';
+
+  return `${prefix}${line}`;
+}
+
 /**
  * Formats php comment
  *
@@ -33,22 +51,4 @@ export function formatPhpComment(comment: string): string {
   });
 
   return mapped.join('\n');
-}
-
-function splitByLines(content: string): Array<string> {
-  return content.split('\n');
-}
-
-function isCommentedLine(line: string): boolean {
-  return line.trim().startsWith('*');
-}
-
-function isMultiline(lines: Array<string>): boolean {
-  return lines.length > 1;
-}
-
-function addPrefixToLine(line: string): string {
-  const prefix = ' ';
-
-  return `${prefix}${line}`;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/166

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/166

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Comment block in raw/directive php block should keep its indentation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
