### PR TITLE
fix: 🐛 body of formField directive does not indent

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4991,4 +4991,25 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@formField directive', async () => {
+    const content = [
+      `@formField('input', [`,
+      `'name' => 'page_title',`,
+      `'label' => 'Page title',`,
+      `'maxlength' => 200`,
+      `])`,
+    ].join('\n');
+
+    const expected = [
+      `@formField('input', [`,
+      `    'name' => 'page_title',`,
+      `    'label' => 'Page title',`,
+      `    'maxlength' => 200,`,
+      `])`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -340,16 +340,19 @@ export default class Formatter {
       ...['@unless\\(.*?\\)'],
     ].join('|');
 
-    const inlineNegativeLookAhead = [
-      ..._.without(indentStartTokens, '@unless'),
+    const inlineNegativeLookAhead = _.chain([
+      ..._.without(indentStartTokens, '@unless', '@for'),
       ...indentEndTokens,
       ...indentElseTokens,
       ...inlineFunctionTokens,
-      ...phpKeywordStartTokens,
-      ...['@unless[a-z]*\\(.*?\\)'],
+      ..._.without(phpKeywordStartTokens, '@for'),
+      ...['@unless[a-z]*\\(.*?\\)', '@for\\(.*?\\)'],
       ...unbalancedStartTokens,
       ...cssAtRuleTokens,
-    ].join('|');
+    ])
+      .uniq()
+      .join('|')
+      .value();
 
     const inlineRegex = new RegExp(
       `(?!(${inlineNegativeLookAhead}))(@([a-zA-Z1-9_\\-]+))(?!.*?@end\\3)${nestedParenthesisRegex}.*?(?<!@end\\5)`,


### PR DESCRIPTION
✅ Closes: https://github.com/shufo/vscode-blade-formatter/issues/647

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/647

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/647

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
