### PR TITLE
fix: 🐛 unexpected comma is inserted before closing parentheses

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4992,3 +4992,39 @@ describe('formatter', () => {
     await util.doubleFormatCheck(content, expected);
   });
 });
+test('comma should not inserted for lastline of inline custom directive ', async () => {
+  const content = [
+    `@livewire(`,
+    `    $block['path'],`,
+    `    [`,
+    `        'componentSettings' => $block['properties'],`,
+    `        'componentKey' => $block['key'],`,
+    `        'site' => $site ?? null,`,
+    `        'post' => $post ?? null,`,
+    `        'theme' => $theme,`,
+    `        'editing' => false,`,
+    `        'preview' => $preview,`,
+    `    ],`,
+    `    key($key)`,
+    `)`,
+  ].join('\n');
+
+  const expected = [
+    `@livewire(`,
+    `    $block['path'],`,
+    `    [`,
+    `        'componentSettings' => $block['properties'],`,
+    `        'componentKey' => $block['key'],`,
+    `        'site' => $site ?? null,`,
+    `        'post' => $post ?? null,`,
+    `        'theme' => $theme,`,
+    `        'editing' => false,`,
+    `        'preview' => $preview,`,
+    `    ],`,
+    `    key($key)`,
+    `)`,
+    ``,
+  ].join('\n');
+
+  await util.doubleFormatCheck(content, expected);
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1898,7 +1898,7 @@ export default class Formatter {
                 printWidth: util.printWidthForInline,
               })
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-              .replace(/,(\s*?\))/gis, (_m, p4) => p4)
+              .replace(/,(\s*?\))$/gm, (_m, p4) => p4)
               .trim()
               .substring(4);
             return `${p2}${this.indentComponentAttribute(indent.indent, formatted)}`;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1898,7 +1898,7 @@ export default class Formatter {
                 printWidth: util.printWidthForInline,
               })
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
-              .replace(/,(\s*?\))/gis, (_m, p2) => p2)
+              .replace(/,(\s*?\))/gis, (_m, p4) => p4)
               .trim()
               .substring(4);
             return `${p2}${this.indentComponentAttribute(indent.indent, formatted)}`;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1898,6 +1898,7 @@ export default class Formatter {
                 printWidth: util.printWidthForInline,
               })
               .replace(/([\n\s]*)->([\n\s]*)/gs, '->')
+              .replace(/,(\s*?\))/gis, (_m, p2) => p2)
               .trim()
               .substring(4);
             return `${p2}${this.indentComponentAttribute(indent.indent, formatted)}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/643

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/643

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
