### PR TITLE
Fix Dockerfile to work, Change python source, Change from npm to yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,8 @@ FROM node:lts-alpine as builder
 
 WORKDIR /blade-formatter
 ADD . .
-RUN apk add --update --no-cache git python gcc g++ make && \
-    npm install --only=prod
-RUN npm rebuild -q && \
-    apk del git python gcc g++ make && \
-    npm cache clean --force && \
-    npm uninstall -g npm && \
-    rm -fR ~/.cache ~/.npm && \
-    ln -s $(pwd)/bin/blade-formatter /usr/local/bin/blade-formatter
+RUN apk add --update --no-cache git python3 gcc g++ make
+RUN yarn install && yarn build
+RUN ln -s $(pwd)/bin/blade-formatter /usr/local/bin/blade-formatter
 
 ENTRYPOINT ["blade-formatter"]


### PR DESCRIPTION
Hello, thanks for this useful software!

## Description

1. Changed python source in Dockerfile.
2. Changed npm install to yarn install in Dockerfile.

## Related Issue
nothing

## Motivation and Context

1. Changed python source in Dockerfile.

python seems to have been discontinued and changed to python3.
ref: https://github.com/docker-library/docker/issues/240

```sh
/ # apk add --update --no-cache git python gcc g++ make
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/aarch64/APKINDEX.tar.gz
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
```

2. Changed npm install to yarn install in Dockerfile.

I'm not very familiar with npm, sorry if it's a wrong fix.

```sh
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: blade-formatter@1.32.5
npm ERR! Found: esbuild@0.17.0
npm ERR! node_modules/esbuild
npm ERR!   dev esbuild@"^0.17.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer esbuild@"0.12 - 0.14" from esbuild-node-externals@1.4.1
npm ERR! node_modules/esbuild-node-externals
npm ERR!   dev esbuild-node-externals@"^1.4.1" from the root project
```

## How Has This Been Tested?

I have confirmed the following behavior.
(Since I am using M1 Chip Mac, I have specified the platform option)

```sh
$ cp vscode-blade-formatter/src/test/fixtures/project/index.blade.php sample.php
$ docker run -it --platform linux/amd64 -v $(pwd):/app -w /app shufo/blade-formatter sample.php 
```

## Screenshots (if appropriate):
