### PR TITLE
feat: add option `--wrap-attributes-min-attrs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
       --wrap-line-length, --wrap      The length of line wrap size  [default: 120]
       --wrap-attributes, --wrap-atts  The way to wrap attributes.
                                       [auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]  [string] [default: "auto"]
+  -M, --wrap-attributes-min-attrs     Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if 'force-expand-multiline' is specified in wrap attributes  [default: "2"]
       --sort-tailwindcss-classes      Sort tailwindcss classes  [boolean] [default: false]
       --tailwindcss-config-path       Specify path of tailwind config  [string] [default: null]
       --sort-html-attributes          Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs", "custom"] [default: none]
@@ -347,7 +348,7 @@ SyntaxError: Unexpected token 'export'
 
 then you should check your nodejs module type is matched with `tailwindcss.config.js`.
 
-### ESM 
+### ESM
 
 `package.json`
 
@@ -363,7 +364,7 @@ export default {
 }
 ```
 
-### CommonJS 
+### CommonJS
 
 `tailwind.config.js`
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ e.g.
   "indentSize": 4,
   "wrapAttributes": "auto",
   "wrapLineLength": 120,
+  "wrapAttributesMinAttrs": 2,
   "endWithNewLine": true,
   "endOfLine": "LF",
   "useTabs": false,

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -37,11 +37,10 @@ describe('The blade formatter CLI', () => {
       path.resolve('__tests__', 'fixtures', 'formatted.edit.blade.php'),
     ];
 
-    let data: string = '';
-    for (let i = 0; i < formattedFiles.length; i++) {
-      data += fs.readFileSync(formattedFiles[i]).toString('utf-8') + '\n';
-    }
-    expect(response).toMatch(data);
+    formattedFiles.forEach((file) => {
+      const data = `${fs.readFileSync(file).toString('utf-8')}\n`;
+      expect(response).toContain(data);
+    });
   });
 
   test.concurrent('should exit with exit code 1 if check option enabled and not formatted', async () => {
@@ -743,11 +742,39 @@ describe('The blade formatter CLI', () => {
     const cmdResult = await cmd.execute(binPath, [
       '--wrap-line-length',
       '40',
-      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'wrapLineLength', 'index.blade.php'),
+      path.resolve('__tests__', 'fixtures', 'index.blade.php'),
     ]);
 
     const formatted = fs.readFileSync(
       path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'wrapLineLength', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('runtime config test (wrap attributes min attrs)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'wrapAttributesMinAttrs', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'wrapAttributesMinAttrs', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('cli argument test (wrap attributes min attrs)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      '--wrap-attributes-min-attrs',
+      '0',
+      '--wrap-attributes',
+      'force-expand-multiline',
+      path.resolve('__tests__', 'fixtures', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'wrapAttributesMinAttrs', 'formatted.index.blade.php'),
     );
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));

--- a/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/.bladeformatterrc.json
+++ b/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/.bladeformatterrc.json
@@ -1,0 +1,4 @@
+{
+  "wrapAttributesMinAttrs": 0,
+  "wrapAttributes": "force-expand-multiline"
+}

--- a/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/formatted.index.blade.php
@@ -1,0 +1,47 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+    <section
+        id="content"
+    >
+        <div
+            class="container mod-users-pd-h"
+        >
+            <div
+                class="pf-user-header"
+            >
+                <div></div>
+                <p>@lang('users.index')</p>
+            </div>
+            <div
+                class="pf-users-branch"
+            >
+                <ul
+                    class="pf-users-branch__list"
+                >
+                    @foreach ($tree as $users)
+                        <li>
+                            <img
+                                src="{{ asset('img/frontend/icon/branch-arrow.svg') }}"
+                                alt="branch_arrow"
+                            >
+                            {{ link_to_route('frontend.users.user.show', $users['name'], $users['_id']) }}
+                        </li>
+                    @endforeach
+                </ul>
+                <div
+                    class="pf-users-branch__btn"
+                >
+                    @can('create', App\Models\User::class)
+                        {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                    @endcan
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+@section('footer')
+@stop

--- a/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/wrapAttributesMinAttrs/index.blade.php
@@ -1,0 +1,32 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+<section id="content">
+    <div class="container mod-users-pd-h">
+        <div class="pf-user-header">
+            <div></div>
+            <p>@lang('users.index')</p>
+        </div>
+        <div class="pf-users-branch">
+            <ul class="pf-users-branch__list">
+                @foreach($tree as $users)
+                <li>
+                    <img src="{{ asset("img/frontend/icon/branch-arrow.svg") }}" alt="branch_arrow">
+                    {{ link_to_route('frontend.users.user.show',$users["name"],$users['_id']) }}
+                </li>
+                @endforeach
+            </ul>
+            <div class="pf-users-branch__btn">
+                @can('create', App\Models\User::class)
+                {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                @endcan
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@section('footer')
+@stop

--- a/__tests__/fixtures/snapshots/wrap_attributes_min_attrs.snapshot
+++ b/__tests__/fixtures/snapshots/wrap_attributes_min_attrs.snapshot
@@ -1,0 +1,86 @@
+------------------------------------options----------------------------------------
+{
+  "wrapAttributesMinAttrs": 0,
+  "wrapAttributes": "force-expand-multiline"
+}
+------------------------------------content----------------------------------------
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+<section id="content">
+    <div class="container mod-users-pd-h">
+        <div class="pf-user-header">
+            <div></div>
+            <p>@lang('users.index')</p>
+        </div>
+        <div class="pf-users-branch">
+            <ul class="pf-users-branch__list">
+                @foreach($tree as $users)
+                <li>
+                    <img src="{{ asset("img/frontend/icon/branch-arrow.svg") }}" alt="branch_arrow">
+                    {{ link_to_route('frontend.users.user.show',$users["name"],$users['_id']) }}
+                </li>
+                @endforeach
+            </ul>
+            <div class="pf-users-branch__btn">
+                @can('create', App\Models\User::class)
+                {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                @endcan
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@section('footer')
+@stop
+------------------------------------expected----------------------------------------
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+    <section
+        id="content"
+    >
+        <div
+            class="container mod-users-pd-h"
+        >
+            <div
+                class="pf-user-header"
+            >
+                <div></div>
+                <p>@lang('users.index')</p>
+            </div>
+            <div
+                class="pf-users-branch"
+            >
+                <ul
+                    class="pf-users-branch__list"
+                >
+                    @foreach ($tree as $users)
+                        <li>
+                            <img
+                                src="{{ asset('img/frontend/icon/branch-arrow.svg') }}"
+                                alt="branch_arrow"
+                            >
+                            {{ link_to_route('frontend.users.user.show', $users['name'], $users['_id']) }}
+                        </li>
+                    @endforeach
+                </ul>
+                <div
+                    class="pf-users-branch__btn"
+                >
+                    @can('create', App\Models\User::class)
+                        {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                    @endcan
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+@section('footer')
+@stop

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5045,4 +5045,30 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('wrapAttributesMinAttrs option', async () => {
+    const content = [
+      `<div name="myname" aria-disabled="true" id="myid" class="myclass" src="other">`,
+      `foo`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div`,
+      `    name="myname"`,
+      `    aria-disabled="true"`,
+      `    id="myid"`,
+      `    class="myclass"`,
+      `    src="other"`,
+      `>`,
+      `    foo`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected, {
+      wrapAttributesMinAttrs: 0,
+      wrapAttributes: 'force-expand-multiline',
+    });
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,12 @@ export default async function cli() {
       description: `The way to wrap attributes.\n[auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]`,
       default: 'auto',
     })
+    .option('wrap-attributes-min-attrs', {
+      type: 'integer',
+      alias: 'M',
+      description: `Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if 'force-expand-multiline' is specified in wrap attributes`,
+      default: '2',
+    })
     .option('sort-tailwindcss-classes', {
       alias: 'sort-classes',
       type: 'boolean',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -244,6 +244,7 @@ export default class Formatter {
       indent_size: util.optional(this.options).indentSize || 4,
       wrap_line_length: util.optional(this.options).wrapLineLength || 120,
       wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
+      wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
       end_with_newline: util.optional(this.options).endWithNewline || true,
       max_preserve_newlines: util.optional(this.options).noMultipleEmptyLines ? 1 : undefined,
       css: {
@@ -1932,6 +1933,7 @@ export default class Formatter {
             indent_size: util.optional(this.options).indentSize || 4,
             wrap_line_length: util.optional(this.options).wrapLineLength || 120,
             wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
+            wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
             indent_with_tabs: useTabs,
             end_with_newline: false,
             templating: ['php'],
@@ -2039,6 +2041,7 @@ export default class Formatter {
           indent_size: util.optional(this.options).indentSize || 4,
           wrap_line_length: util.optional(this.options).wrapLineLength || 120,
           wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
+          wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
           end_with_newline: false,
           templating: ['php'],
         };

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export type FormatterOption = {
   indentSize?: number;
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
+  wrapAttributesMinAttrs?: number;
   endWithNewline?: boolean;
   endOfLine?: EndOfLine;
   useTabs?: boolean;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -22,6 +22,7 @@ export interface RuntimeConfig {
   indentSize?: number;
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
+  wrapAttributesMinAttrs?: number;
   endWithNewline?: boolean;
   endOfLine?: EndOfLine;
   useTabs?: boolean;
@@ -76,6 +77,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
         ],
         nullable: true,
       },
+      wrapAttributesMinAttrs: { type: 'integer', nullable: true, default: 2 },
       endWithNewline: { type: 'boolean', nullable: true },
       endOfLine: { type: 'string', enum: ['LF', 'CRLF'], nullable: true },
       useTabs: { type: 'boolean', nullable: true },


### PR DESCRIPTION
- feat: 🎸 add option `--wrap-attributes-min-attrs`
- test: 💍 add tests for wrapAttributesMinAttrs option

## Description

<!--- Describe your changes in detail -->

This PR adds option `--wrap-attributes-min-attrs`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`js-beautify` adds option `--wrap-attributes-min-attrs` in recent version.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
