### PR TITLE
fix: 🐛 script does not format when type is module

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -4245,6 +4245,75 @@ describe('formatter', () => {
     await util.doubleFormatCheck(content, expected);
   });
 
+  test('script tag with module type', async () => {
+    const content = [
+      `@push('scripts')`,
+      `    <script type="module">`,
+      `    $("#table-kategori").DataTable({`,
+      `    processing: true,`,
+      `    serverSide: true,ajax: "{{ route('kategori.list') }}",`,
+      `    columns: [{data: "DT_RowIndex",`,
+      `       name: "DT_RowIndex",orderable: false,searchable: false`,
+      `     },`,
+      `        {    data: "nama",name: "nama"`,
+      `      },`,
+      `         {`,
+      `         data: "jumlah_barang",`,
+      `         name: "jumlah_barang"`,
+      `       },`,
+      `       {`,
+      `       data: "created_at",`,
+      `       name: "created_at"`,
+      `       },`,
+      `       {`,
+      `       data: "action",`,
+      `       name: "action"`,
+      `       },`,
+      `       ],`,
+      `        });`,
+      `    </script>`,
+      `@endpush`,
+    ].join('\n');
+
+    const expected = [
+      `@push('scripts')`,
+      `    <script type="module">`,
+      `        $("#table-kategori").DataTable({`,
+      `            processing: true,`,
+      `            serverSide: true,`,
+      `            ajax: "{{ route('kategori.list') }}",`,
+      `            columns: [{`,
+      `                    data: "DT_RowIndex",`,
+      `                    name: "DT_RowIndex",`,
+      `                    orderable: false,`,
+      `                    searchable: false`,
+      `                },`,
+      `                {`,
+      `                    data: "nama",`,
+      `                    name: "nama"`,
+      `                },`,
+      `                {`,
+      `                    data: "jumlah_barang",`,
+      `                    name: "jumlah_barang"`,
+      `                },`,
+      `                {`,
+      `                    data: "created_at",`,
+      `                    name: "created_at"`,
+      `                },`,
+      `                {`,
+      `                    data: "action",`,
+      `                    name: "action"`,
+      `                },`,
+      `            ],`,
+      `        });`,
+      `    </script>`,
+      `@endpush`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
+
   test('escaped quote in raw php directive #669', async () => {
     const content = [
       `    @php`,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -856,7 +856,7 @@ export default class Formatter {
   async preserveNonnativeScripts(content: string) {
     return _.replace(
       content,
-      /<script[^>]*?type=(["'])(?!text\/javascript)[^\1]*?\1[^>]*?>.*?<\/script>/gis,
+      /<script[^>]*?type=(["'])(?!(text\/javascript|module))[^\1]*?\1[^>]*?>.*?<\/script>/gis,
       (match: string) => this.storeNonnativeScripts(match),
     );
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes the problem of https://github.com/shufo/vscode-blade-formatter/issues/727

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/vscode-blade-formatter/issues/727

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
