### PR TITLE
feat: add option `--indent-inner-html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
       --wrap-attributes, --wrap-atts  The way to wrap attributes.
                                       [auto|force|force-aligned|force-expand-multiline|aligned-multiple|preserve|preserve-aligned]  [string] [default: "auto"]
   -M, --wrap-attributes-min-attrs     Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if 'force-expand-multiline' is specified in wrap attributes  [default: "2"]
+  -I, --indent-inner-html             Indent <head> and <body> sections in html.  [boolean] [default: false]
       --sort-tailwindcss-classes      Sort tailwindcss classes  [boolean] [default: false]
       --tailwindcss-config-path       Specify path of tailwind config  [string] [default: null]
       --sort-html-attributes          Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs", "custom"] [default: none]
@@ -211,6 +212,7 @@ e.g.
   "wrapAttributes": "auto",
   "wrapLineLength": 120,
   "wrapAttributesMinAttrs": 2,
+  "indentInnerHtml": true,
   "endWithNewLine": true,
   "endOfLine": "LF",
   "useTabs": false,

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -779,4 +779,30 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent('runtime config test (indent inner html)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'indentInnerHtml', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'indentInnerHtml', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('cli argument test (indent inner html)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      '--indent-inner-html',
+      'true',
+      path.resolve('__tests__', 'fixtures', 'argumentTest', 'indentInnerHtml', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'argumentTest', 'indentInnerHtml', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/fixtures/argumentTest/indentInnerHtml/formatted.index.blade.php
+++ b/__tests__/fixtures/argumentTest/indentInnerHtml/formatted.index.blade.php
@@ -1,0 +1,17 @@
+<html>
+
+    <head>
+        @section('header')
+            <title>
+                foo
+            </title>
+        @endsection
+    </head>
+
+    <body>
+        <button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+            Click Here
+        </button>
+    </body>
+
+</html>

--- a/__tests__/fixtures/argumentTest/indentInnerHtml/index.blade.php
+++ b/__tests__/fixtures/argumentTest/indentInnerHtml/index.blade.php
@@ -1,0 +1,14 @@
+<html>
+<head>
+@section('header')
+<title>
+foo
+</title>
+@endsection
+</head>
+<body>
+<button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+Click Here
+</button>
+</body>
+</html>

--- a/__tests__/fixtures/runtimeConfig/indentInnerHtml/.bladeformatterrc.json
+++ b/__tests__/fixtures/runtimeConfig/indentInnerHtml/.bladeformatterrc.json
@@ -1,0 +1,3 @@
+{
+  "indentInnerHtml": true
+}

--- a/__tests__/fixtures/runtimeConfig/indentInnerHtml/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/indentInnerHtml/formatted.index.blade.php
@@ -1,0 +1,17 @@
+<html>
+
+    <head>
+        @section('header')
+            <title>
+                foo
+            </title>
+        @endsection
+    </head>
+
+    <body>
+        <button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+            Click Here
+        </button>
+    </body>
+
+</html>

--- a/__tests__/fixtures/runtimeConfig/indentInnerHtml/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/indentInnerHtml/index.blade.php
@@ -1,0 +1,14 @@
+<html>
+<head>
+@section('header')
+<title>
+foo
+</title>
+@endsection
+</head>
+<body>
+<button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+Click Here
+</button>
+</body>
+</html>

--- a/__tests__/fixtures/snapshots/indent_inner_html.snapshot
+++ b/__tests__/fixtures/snapshots/indent_inner_html.snapshot
@@ -1,0 +1,37 @@
+------------------------------------options----------------------------------------
+{
+  "indentInnerHtml": true
+}
+------------------------------------content----------------------------------------
+<html>
+<head>
+@section('header')
+<title>
+foo
+</title>
+@endsection
+</head>
+<body>
+<button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+Click Here
+</button>
+</body>
+</html>
+------------------------------------expected----------------------------------------
+<html>
+
+    <head>
+        @section('header')
+            <title>
+                foo
+            </title>
+        @endsection
+    </head>
+
+    <body>
+        <button className="prettier-class" id="prettier-id" onClick={this.handleClick}>
+            Click Here
+        </button>
+    </body>
+
+</html>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,12 @@ export default async function cli() {
       description: `Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if 'force-expand-multiline' is specified in wrap attributes`,
       default: '2',
     })
+    .option('indent-inner-html', {
+      alias: 'I',
+      type: 'boolean',
+      description: 'Indent <head> and <body> sections in html.',
+      default: false,
+    })
     .option('sort-tailwindcss-classes', {
       alias: 'sort-classes',
       type: 'boolean',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -245,6 +245,7 @@ export default class Formatter {
       wrap_line_length: util.optional(this.options).wrapLineLength || 120,
       wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
       wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
+      indent_inner_html: util.optional(this.options).indentInnerHtml || false,
       end_with_newline: util.optional(this.options).endWithNewline || true,
       max_preserve_newlines: util.optional(this.options).noMultipleEmptyLines ? 1 : undefined,
       css: {
@@ -1934,6 +1935,7 @@ export default class Formatter {
             wrap_line_length: util.optional(this.options).wrapLineLength || 120,
             wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
             wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
+            indent_inner_html: util.optional(this.options).indentInnerHtml || false,
             indent_with_tabs: useTabs,
             end_with_newline: false,
             templating: ['php'],
@@ -2042,6 +2044,7 @@ export default class Formatter {
           wrap_line_length: util.optional(this.options).wrapLineLength || 120,
           wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
           wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
+          indent_inner_html: util.optional(this.options).indentInnerHtml || false,
           end_with_newline: false,
           templating: ['php'],
         };

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ export type FormatterOption = {
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
   wrapAttributesMinAttrs?: number;
+  indentInnerHtml?: boolean;
   endWithNewline?: boolean;
   endOfLine?: EndOfLine;
   useTabs?: boolean;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -23,6 +23,7 @@ export interface RuntimeConfig {
   wrapLineLength?: number;
   wrapAttributes?: WrapAttributes;
   wrapAttributesMinAttrs?: number;
+  indentInnerHtml?: boolean;
   endWithNewline?: boolean;
   endOfLine?: EndOfLine;
   useTabs?: boolean;
@@ -78,6 +79,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
         nullable: true,
       },
       wrapAttributesMinAttrs: { type: 'integer', nullable: true, default: 2 },
+      indentInnerHtml: { type: 'boolean', nullable: true },
       endWithNewline: { type: 'boolean', nullable: true },
       endOfLine: { type: 'string', enum: ['LF', 'CRLF'], nullable: true },
       useTabs: { type: 'boolean', nullable: true },


### PR DESCRIPTION
- feat: 🎸 add option `--indent-inner-html`
- test: 💍 add test for indentInnerHtml option

## Description

<!--- Describe your changes in detail -->

This PR adds option `--indent-inner-html`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/219

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This type of formatting option was requested several times.
js-beautify option `--indent-inner-html` option solves this.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
