### PR TITLE
added support for html-beautify extra liners option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
       --sort-html-attributes          Sort HTML attributes.  [string] [choices: "none", "alphabetical", "code-guide", "idiomatic", "vuejs", "custom"] [default: none]
       --custom-html-attributes-order  Comma separated custom HTML attributes order. To enable this you must specify sort html attributes option as `custom`. You can use regex for attribute names. [string] [default: null]
       --no-single-quote               Use double quotes instead of single quotes for php expression.  [boolean] [default: false]
+      --extra-liners                  Comma separated list of tags that should have an extra newline before them.  [string] (default: ['head', 'body', '/html'])
       --no-multiple-empty-lines       Merge multiple blank lines into a single blank line  [boolean] [default: false]
       --no-php-syntax-check           Disable PHP sytnax checking  [boolean] [default: false]
   -p, --progress                      Print progress  [boolean] [default: false]
@@ -220,7 +221,8 @@ e.g.
   "sortHtmlAttributes": "none",
   "noMultipleEmptyLines": false,
   "noPhpSyntaxCheck": false,
-  "noSingleQuote": false
+  "noSingleQuote": false,
+  "extraLiners": []
 }
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,15 @@
-import yargs from 'yargs';
-import concat from 'concat-stream';
-import { loadWASM } from 'vscode-oniguruma';
 import chalk from 'chalk';
+import concat from 'concat-stream';
 import _ from 'lodash';
+import { loadWASM } from 'vscode-oniguruma';
+import yargs from 'yargs';
 
-import os from 'os';
 import { promises as fs } from 'fs';
+import os from 'os';
 
 import { hideBin } from 'yargs/helpers';
-import { BladeFormatter } from './main';
 import { name, version } from '../package.json';
+import { BladeFormatter } from './main';
 
 export default async function cli() {
   // @ts-ignore
@@ -116,6 +116,11 @@ export default async function cli() {
       description: 'this is a workaround for combine strict && boolean option',
       hidden: true,
       default: true,
+    })
+    .option('extra-liners', {
+      type: 'string',
+      description: 'Comma separated list of tags that should have an extra newline before them (defaults to [head,body,/html]).',
+      default: null,
     })
     .option('no-multiple-empty-lines', {
       type: 'boolean',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,40 +1,40 @@
 /* eslint-disable class-methods-use-this */
 
+import { sortClasses } from '@shufo/tailwindcss-class-sorter';
+import Aigle from 'aigle';
+import detectIndent from 'detect-indent';
+import { sortAttributes } from 'html-attribute-sorter';
 import beautify, { JSBeautifyOptions } from 'js-beautify';
 import _ from 'lodash';
 import * as vscodeTmModule from 'vscode-textmate';
-import detectIndent from 'detect-indent';
-import Aigle from 'aigle';
 import xregexp from 'xregexp';
-import { sortClasses } from '@shufo/tailwindcss-class-sorter';
-import { sortAttributes } from 'html-attribute-sorter';
-import { FormatterOption, CLIOption, BladeFormatterOption } from './main';
-import * as vsctm from './vsctm';
-import * as util from './util';
+import { formatPhpComment } from './comment';
+import constants from './constants';
 import {
-  indentStartTokens,
-  indentEndTokens,
-  indentElseTokens,
-  indentStartOrElseTokens,
-  tokenForIndentStartOrElseTokens,
-  hasStartAndEndToken,
-  phpKeywordStartTokens,
-  phpKeywordEndTokens,
-  indentStartAndEndTokens,
-  inlineFunctionTokens,
-  optionalStartWithoutEndTokens,
   conditionalTokens,
-  directivePrefix,
-  indentStartTokensWithoutPrefix,
-  unbalancedStartTokens,
   cssAtRuleTokens,
+  directivePrefix,
+  hasStartAndEndToken,
+  indentElseTokens,
+  indentEndTokens,
+  indentStartAndEndTokens,
+  indentStartOrElseTokens,
+  indentStartTokens,
+  indentStartTokensWithoutPrefix,
+  inlineFunctionTokens,
   inlinePhpDirectives,
+  optionalStartWithoutEndTokens,
+  phpKeywordEndTokens,
+  phpKeywordStartTokens,
+  tokenForIndentStartOrElseTokens,
+  unbalancedStartTokens,
 } from './indent';
+import { BladeFormatterOption, CLIOption, FormatterOption } from './main';
 import { nestedParenthesisRegex } from './regex';
 import { SortHtmlAttributes } from './runtimeConfig';
-import { formatPhpComment } from './comment';
 import { adjustSpaces } from './space';
-import constants from './constants';
+import * as util from './util';
+import * as vsctm from './vsctm';
 
 export default class Formatter {
   argumentCheck: any;
@@ -248,6 +248,7 @@ export default class Formatter {
       indent_inner_html: util.optional(this.options).indentInnerHtml || false,
       end_with_newline: util.optional(this.options).endWithNewline || true,
       max_preserve_newlines: util.optional(this.options).noMultipleEmptyLines ? 1 : undefined,
+      extra_liners: util.optional(this.options).extraLiners || ['head', 'body', '/html'],
       css: {
         end_with_newline: false,
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,25 +1,25 @@
 import ignore from 'ignore';
 
-import nodepath from 'path';
-import fs from 'fs';
-import process from 'process';
 import chalk from 'chalk';
-import glob from 'glob';
-import nodeutil from 'util';
-import _ from 'lodash';
 import findConfig from 'find-config';
+import fs from 'fs';
+import glob from 'glob';
+import _ from 'lodash';
+import nodepath from 'path';
+import process from 'process';
 import { Config as TailwindConfig } from 'tailwindcss/types/config';
+import nodeutil from 'util';
+import FormatError from './errors/formatError';
 import Formatter from './formatter';
-import * as util from './util';
 import {
-  findRuntimeConfig,
-  readRuntimeConfig,
   EndOfLine,
   RuntimeConfig,
   SortHtmlAttributes,
   WrapAttributes,
+  findRuntimeConfig,
+  readRuntimeConfig,
 } from './runtimeConfig';
-import FormatError from './errors/formatError';
+import * as util from './util';
 
 export type CLIOption = {
   write?: boolean;
@@ -47,6 +47,7 @@ export type FormatterOption = {
   noMultipleEmptyLines?: boolean;
   noPhpSyntaxCheck?: boolean;
   noSingleQuote?: boolean;
+  extraLiners?: string[];
 };
 
 export type BladeFormatterOption = CLIOption & FormatterOption;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -1,7 +1,7 @@
-import path from 'path';
-import fs from 'fs';
 import Ajv, { JSONSchemaType } from 'ajv';
 import findConfig from 'find-config';
+import fs from 'fs';
+import path from 'path';
 
 const ajv = new Ajv();
 
@@ -34,6 +34,7 @@ export interface RuntimeConfig {
   noMultipleEmptyLines?: boolean;
   noPhpSyntaxCheck?: boolean;
   noSingleQuote?: boolean;
+  extraLiners?: string[];
 }
 
 const defaultConfigNames = ['.bladeformatterrc.json', '.bladeformatterrc'];
@@ -94,6 +95,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
       noMultipleEmptyLines: { type: 'boolean', nullable: true },
       noPhpSyntaxCheck: { type: 'boolean', nullable: true },
       noSingleQuote: { type: 'boolean', nullable: true },
+      extraLiners: { type: 'array', nullable: true, items: { type: 'string' }, default: [] },
     },
     additionalProperties: true,
   };


### PR DESCRIPTION
## Description

Adding the functionality from the pull request title as an option for the Blade Formatter, modifying the behaviour of [html-beautify](https://github.com/beautify-web/js-beautify#css--html) with the extra liners option as array..

## Related Issue
https://github.com/shufo/blade-formatter/issues/842

## Motivation and Context
I think external code formatting, even if opinionated, should be flexible enough to fit the settings one can achieve with native IDE formatting, especially if it improves them. So one gaines more formatting features without losing those already being used to.

## How Has This Been Tested?
Test Suites: 7 passed, 7 total
Tests:           299 passed, 299 total
Snapshots: 0 total
Time:           38.94 s