### PR TITLE
fix: 🐛 unbalanced x-slot tag behaviour

### DIFF
--- a/__tests__/fixtures/snapshots/unmatched_xslot_close_tag.snapshot
+++ b/__tests__/fixtures/snapshots/unmatched_xslot_close_tag.snapshot
@@ -1,0 +1,49 @@
+------------------------------------options----------------------------------------
+{
+  "wrapAttributes": "force-expand-multiline",
+  "wrapAttributesMinAttrs": 1
+}
+------------------------------------content----------------------------------------
+<x-alert>
+    <x-slot:title name="f>oo"
+value="bar">
+        Foo bar
+    </x-slot>
+          <x-slot name="foo">
+           Foo bar
+    </x-slot:title>
+          <x-slot:title>
+        Foo bar
+    </x-slot:title>
+        <x-slot:foo>
+        Foo bar
+              <x-slot:bar>
+            Foo bar
+            </x-slot>
+            Foo bar
+        </x-slot>
+      </x-alert>
+------------------------------------expected----------------------------------------
+<x-alert>
+    <x-slot:title
+        name="f>oo"
+        value="bar"
+    >
+        Foo bar
+    </x-slot>
+    <x-slot
+        name="foo"
+    >
+        Foo bar
+    </x-slot:title>
+    <x-slot:title>
+        Foo bar
+    </x-slot:title>
+    <x-slot:foo>
+        Foo bar
+        <x-slot:bar>
+            Foo bar
+        </x-slot>
+        Foo bar
+    </x-slot>
+</x-alert>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5240,4 +5240,52 @@ describe('formatter', () => {
       extraLiners: [],
     });
   });
+
+  test('unmatched x-slot close tag', async () => {
+    const content = [
+      `<x-alert>`,
+      `    <x-slot:title name="f>oo"`,
+      `value="bar">`,
+      `        Foo bar`,
+      `    </x-slot>`,
+      `          <x-slot name="foo">`,
+      `           Foo bar`,
+      `    </x-slot:title>`,
+      `          <x-slot:title>`,
+      `        Foo bar`,
+      `    </x-slot:title>`,
+      `        <x-slot:foo>`,
+      `        Foo bar`,
+      `              <x-slot:bar>`,
+      `            Foo bar`,
+      `            </x-slot>`,
+      `            Foo bar`,
+      `        </x-slot>`,
+      `      </x-alert>`,
+    ].join('\n');
+
+    const expected = [
+      `<x-alert>`,
+      `    <x-slot:title name="f>oo" value="bar">`,
+      `        Foo bar`,
+      `    </x-slot>`,
+      `    <x-slot name="foo">`,
+      `        Foo bar`,
+      `    </x-slot:title>`,
+      `    <x-slot:title>`,
+      `        Foo bar`,
+      `    </x-slot:title>`,
+      `    <x-slot:foo>`,
+      `        Foo bar`,
+      `        <x-slot:bar>`,
+      `            Foo bar`,
+      `        </x-slot>`,
+      `        Foo bar`,
+      `    </x-slot>`,
+      `</x-alert>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1686,7 +1686,7 @@ export default class Formatter {
   restoreXslot(content: string) {
     return _.replace(content, /x-slot\s*--___(\d+)___--/gms, (_match: string, p1: number) => this.xSlot[p1]).replace(
       /(?<=<x-slot:[\w\_\-]*)\s+(?=\/?>)/gm,
-      (_match: string) => '',
+      () => '',
     );
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -357,6 +357,7 @@ const escapeTags = [
   '@customdirective',
   '@elsecustomdirective',
   '@endcustomdirective',
+  'x-slot --___\\d+___--',
 ];
 
 export function checkResult(formatted: any) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/blade-formatter/issues/851

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/blade-formatter/issues/851

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Laravel allows unbalanced closing x-slot tag. So we should match <x-slot:~> tag to closing </x-slot> tag on indent.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
