### PR TITLE
feat: 🎸 add option `--no-trailing-comma-php`

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -831,4 +831,29 @@ describe('The blade formatter CLI', () => {
 
     expect(cmdResult).toEqual(formatted.toString('utf-8'));
   });
+
+  test.concurrent('runtime config test (trailing comma php)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'trailingCommaPhp', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'runtimeConfig', 'trailingCommaPhp', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
+
+  test.concurrent('cli argument test (trailing comma php)', async () => {
+    const cmdResult = await cmd.execute(binPath, [
+      '--no-trailing-comma-php',
+      path.resolve('__tests__', 'fixtures', 'argumentTest', 'trailingCommaPhp', 'index.blade.php'),
+    ]);
+
+    const formatted = fs.readFileSync(
+      path.resolve('__tests__', 'fixtures', 'argumentTest', 'trailingCommaPhp', 'formatted.index.blade.php'),
+    );
+
+    expect(cmdResult).toEqual(formatted.toString('utf-8'));
+  });
 });

--- a/__tests__/fixtures/argumentTest/trailingCommaPhp/formatted.index.blade.php
+++ b/__tests__/fixtures/argumentTest/trailingCommaPhp/formatted.index.blade.php
@@ -1,0 +1,9 @@
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required'
+    ] + ($refundId ? ['disabled' => 'true'] : [])
+) !!}

--- a/__tests__/fixtures/argumentTest/trailingCommaPhp/index.blade.php
+++ b/__tests__/fixtures/argumentTest/trailingCommaPhp/index.blade.php
@@ -1,0 +1,9 @@
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required',
+    ] + ($refundId ? ['disabled' => 'true'] : []),
+) !!}

--- a/__tests__/fixtures/runtimeConfig/trailingCommaPhp/.bladeformatterrc
+++ b/__tests__/fixtures/runtimeConfig/trailingCommaPhp/.bladeformatterrc
@@ -1,0 +1,3 @@
+{
+  "noTrailingCommaPhp": true
+}

--- a/__tests__/fixtures/runtimeConfig/trailingCommaPhp/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/trailingCommaPhp/formatted.index.blade.php
@@ -1,0 +1,9 @@
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required'
+    ] + ($refundId ? ['disabled' => 'true'] : [])
+) !!}

--- a/__tests__/fixtures/runtimeConfig/trailingCommaPhp/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/trailingCommaPhp/index.blade.php
@@ -1,0 +1,9 @@
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required',
+    ] + ($refundId ? ['disabled' => 'true'] : []),
+) !!}

--- a/__tests__/fixtures/snapshots/trailing_comma_php.snapshot
+++ b/__tests__/fixtures/snapshots/trailing_comma_php.snapshot
@@ -1,0 +1,24 @@
+------------------------------------options----------------------------------------
+{
+  "noTrailingCommaPhp": true
+}
+------------------------------------content----------------------------------------
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required',
+    ] + ($refundId ? ['disabled' => 'true'] : []),
+) !!}
+------------------------------------expected----------------------------------------
+{!! Form::select(
+    'refundType',
+    REFUND_TYPES,
+    $data->refundType ?? null,
+    [
+        'class' => 'form-control refundType',
+        'required' => 'required'
+    ] + ($refundId ? ['disabled' => 'true'] : [])
+) !!}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,6 +150,17 @@ export default async function cli() {
       hidden: true,
       default: true,
     })
+    .option('no-trailing-comma-php', {
+      type: 'boolean',
+      description: 'If set to true, no trailing commas are printed for php expression.',
+      default: false,
+    })
+    .option('trailing-comma-php', {
+      type: 'boolean',
+      description: 'this is a workaround for combine strict && boolean option',
+      hidden: true,
+      default: true,
+    })
     .option('progress', {
       alias: 'p',
       type: 'boolean',
@@ -194,6 +205,7 @@ export default async function cli() {
     .set('noMultipleEmptyLines', !parsed.argv.multipleEmptyLines)
     .set('noPhpSyntaxCheck', !parsed.argv.phpSyntaxCheck)
     .set('noSingleQuote', !parsed.argv.singleQuote)
+    .set('noTrailingCommaPhp', !parsed.argv.trailingCommaPhp)
     .value();
 
   if (parsed.argv.stdin) {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -131,6 +131,7 @@ export default class Formatter {
     this.options = {
       ...{
         noPhpSyntaxCheck: false,
+        trailingCommaPHP: !options.noTrailingCommaPhp,
         printWidth: options.wrapLineLength || constants.defaultPrintWidth,
       },
       ...options,

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ export type FormatterOption = {
   noMultipleEmptyLines?: boolean;
   noPhpSyntaxCheck?: boolean;
   noSingleQuote?: boolean;
+  noTrailingCommaPhp?: boolean;
   extraLiners?: string[];
 };
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -34,6 +34,7 @@ export interface RuntimeConfig {
   noMultipleEmptyLines?: boolean;
   noPhpSyntaxCheck?: boolean;
   noSingleQuote?: boolean;
+  noTrailingCommaPhp?: boolean;
   extraLiners?: string[];
 }
 
@@ -95,6 +96,7 @@ export async function readRuntimeConfig(filePath: string | null): Promise<Runtim
       noMultipleEmptyLines: { type: 'boolean', nullable: true },
       noPhpSyntaxCheck: { type: 'boolean', nullable: true },
       noSingleQuote: { type: 'boolean', nullable: true },
+      noTrailingCommaPhp: { type: 'boolean', nullable: true },
       extraLiners: { type: 'array', nullable: true, items: { type: 'string' }, default: ['head', 'body', '/html'] },
     },
     additionalProperties: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds option `--no-trailing-comma-php`.
If set to true, no trailing commas are printed for php expression.',

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/231

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PHP version below 7.2 can't recognize trailing comma on php expression. So we should support `trailingCommaPHP` option in `@prettier/plugin-php` for backward compatibility.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
