### PR TITLE
fix/component attribute behind arrow

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -547,7 +547,7 @@ describe('The blade formatter CLI', () => {
     const startTime = performance.now();
     await util.checkIfTemplateIsFormattedTwice(input, target);
     const endTime = performance.now();
-    expect(endTime - startTime).toBeLessThan(8000);
+    expect(endTime - startTime).toBeLessThan(10000);
   });
 
   test.concurrent('respect tailwind.config.js automatically', async () => {

--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -1,6 +1,6 @@
 @section('body')
-    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"
-        :inline="true" :options="[
+    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type" :inline="true"
+        :options="[
             'single' => ['label' => 'Default'],
             'series' => ['label' => 'Recurring meeting'],
             'scheduler' => ['label' => 'Find a meeting date'],

--- a/__tests__/fixtures/formatted.component_attribute.blade.php
+++ b/__tests__/fixtures/formatted.component_attribute.blade.php
@@ -1,6 +1,6 @@
 @section('body')
-    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type" :inline="true"
-        :options="[
+    <x-forms.radios legend="Meeting Schedule" name="meeting_type" value="single" v-model="form.meeting_type"
+        :inline="true" :options="[
             'single' => ['label' => 'Default'],
             'series' => ['label' => 'Recurring meeting'],
             'scheduler' => ['label' => 'Find a meeting date'],

--- a/__tests__/fixtures/snapshots/attribute_without_value.snapshot
+++ b/__tests__/fixtures/snapshots/attribute_without_value.snapshot
@@ -1,0 +1,40 @@
+------------------------------------options----------------------------------------
+{}
+------------------------------------content----------------------------------------
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" href="../images/favicon.ico">
+
+    <title>Mahjong Peoples Relations Management - Log in </title>
+
+    <!-- Vendors Style-->
+    <link rel="stylesheet" href="{{ asset('backend/css/vendors_css.css') }}">
+
+    <!-- Style-->
+    <link rel="stylesheet" href="{{ asset('backend/css/style.css') }}">
+    <link rel="stylesheet" href="{{ asset('backend/css/skin_color.css') }}">
+
+</head>
+------------------------------------expected----------------------------------------
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" href="../images/favicon.ico">
+
+    <title>Mahjong Peoples Relations Management - Log in </title>
+
+    <!-- Vendors Style-->
+    <link rel="stylesheet" href="{{ asset('backend/css/vendors_css.css') }}">
+
+    <!-- Style-->
+    <link rel="stylesheet" href="{{ asset('backend/css/style.css') }}">
+    <link rel="stylesheet" href="{{ asset('backend/css/skin_color.css') }}">
+
+</head>

--- a/__tests__/fixtures/snapshots/component_behind_arrow.snapshot
+++ b/__tests__/fixtures/snapshots/component_behind_arrow.snapshot
@@ -1,0 +1,16 @@
+------------------------------------options----------------------------------------
+{
+  "wrapAttributes": "force-expand-multiline"
+}
+------------------------------------content----------------------------------------
+<x-input
+    type="text"
+    name="filter[date][<=]"
+    :value="format_datetime($request->filter('date.<='))"
+/>
+------------------------------------expected----------------------------------------
+<x-input
+    type="text"
+    name="filter[date][<=]"
+    :value="format_datetime($request->filter('date.<='))"
+/>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2115,10 +2115,12 @@ describe('formatter', () => {
 
     const expected = [
       `<password-input name="password_confirmation" type="password"`,
-      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: " outlined>`,
+      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,
+      `    outlined>`,
       `</password-input>`,
       `<password-input name="password_confirmation" type="password"`,
-      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: " outlined>`,
+      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,
+      `    outlined>`,
       `</password-input>`,
       `<password-input name="password_confirmation" type="password"`,
       `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -2115,12 +2115,10 @@ describe('formatter', () => {
 
     const expected = [
       `<password-input name="password_confirmation" type="password"`,
-      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,
-      `    outlined>`,
+      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: " outlined>`,
       `</password-input>`,
       `<password-input name="password_confirmation" type="password"`,
-      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,
-      `    outlined>`,
+      `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: " outlined>`,
       `</password-input>`,
       `<password-input name="password_confirmation" type="password"`,
       `    @if ('password') error error-message="{{ $message }}" @endif placeholder="password: "`,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -880,7 +880,7 @@ export default class Formatter {
   async preserveHtmlAttributes(content: any) {
     return _.replace(
       content,
-      /(?<=<[\w\-\.\:\_]+[^]*\s)(?!x-bind)([^\s\:][^\s]+\s*=\s*(["'])(?<!\\)[^\2]+?(?<!\\)\2)(?=[^]*(?<!=)\/?>)/gms,
+      /(?<=<[\w\-\.\:\_]+[^]*\s)(?!x-bind)([^\s\:][^\s]+\s*=\s*(["'])(?<!\\)[^\2]*?(?<!\\)\2)(?=[^]*(?<!=)\/?>)/gms,
       (match: string) => `${this.storeHtmlAttribute(match)}`,
     );
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -208,21 +208,21 @@ export default class Formatter {
       .then((target) => this.sortTailwindcssClasses(target))
       .then((target) => this.formatXInit(target))
       .then((target) => this.formatXData(target))
+      .then((target) => this.preservePhpBlock(target))
+      .then((target) => this.sortHtmlAttributes(target))
+      .then((target) => this.preserveHtmlAttributes(target))
       .then((target) => this.preserveComponentAttribute(target))
       .then((target) => this.preserveShorthandBinding(target))
-      .then((target) => this.sortHtmlAttributes(target))
-      .then((target) => this.preservePhpBlock(target))
-      .then((target) => this.preserveHtmlAttributes(target))
       .then((target) => this.preserveXslot(target))
       .then((target) => this.preserveHtmlTags(target))
       .then((target) => this.formatAsHtml(target))
       .then((target) => this.formatAsBlade(target))
       .then((target) => this.restoreHtmlTags(target))
       .then((target) => this.restoreXslot(target))
-      .then((target) => this.restoreHtmlAttributes(target))
-      .then((target) => this.restorePhpBlock(target))
       .then((target) => this.restoreShorthandBinding(target))
       .then((target) => this.restoreComponentAttribute(target))
+      .then((target) => this.restoreHtmlAttributes(target))
+      .then((target) => this.restorePhpBlock(target))
       .then((target) => this.restoreXData(target))
       .then((target) => this.restoreXInit(target))
       .then((target) => this.restoreScripts(target))
@@ -880,7 +880,7 @@ export default class Formatter {
   async preserveHtmlAttributes(content: any) {
     return _.replace(
       content,
-      /(?<=<[\w]*?[\s].*?)[\w\-\_\:]+?=(["']).*?(?<!\\)\1(?=.*?(?<!=)>)/gms,
+      /(?<=\s)([\w\-\_\.]+\s*=\s*(["'])[^\2]*?(?<!\\)\2)/gms,
       (match: string) => `${this.storeHtmlAttribute(match)}`,
     );
   }
@@ -907,7 +907,7 @@ export default class Formatter {
   async preserveShorthandBinding(content: string) {
     return _.replace(
       content,
-      /(?<=<(?!livewire:)[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
+      /(?<=<(?!livewire:)[^<]*?(\s|x-bind)):{1}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^\2]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeShorthandBinding(match)}`,
     );
   }
@@ -915,7 +915,7 @@ export default class Formatter {
   async preserveComponentAttribute(content: string) {
     return _.replace(
       content,
-      /(?<=<(x-|livewire:)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^]*?\2(?=[^>]*?\/*?>)/gim,
+      /(?<=<(x-|livewire:)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^\2]*?\2(?=[^>]*?\/*?>)/gim,
       (match: any) => `${this.storeComponentAttribute(match)}`,
     );
   }
@@ -2216,13 +2216,13 @@ export default class Formatter {
 
             if (this.isInline(p4)) {
               try {
-                return `${p2}${p3}${beautify.js_beautify(p4, beautifyOpts).trimEnd()}`;
+                return `${p2}${p3}${beautify.js_beautify(p4.trim(), beautifyOpts).trim()}`;
               } catch (error) {
-                return `${p2}${p3}${p4}`;
+                return `${p2}${p3}${p4.trim()}`;
               }
             }
 
-            return `${p2}${p3}${beautify.js_beautify(p4, beautifyOpts).trimEnd()}`;
+            return `${p2}${p3}${beautify.js_beautify(p4.trim(), beautifyOpts).trim()}`;
           },
         );
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -880,7 +880,7 @@ export default class Formatter {
   async preserveHtmlAttributes(content: any) {
     return _.replace(
       content,
-      /(?<=\s)([\w\-\_\.]+\s*=\s*(["'])[^\2]*?(?<!\\)\2)/gms,
+      /(?<=<[\w\-\.\:\_]+[^]*\s)(?!x-bind)([^\s\:][^\s]+\s*=\s*(["'])(?<!\\)[^\2]+?(?<!\\)\2)(?=[^]*(?<!=)\/?>)/gms,
       (match: string) => `${this.storeHtmlAttribute(match)}`,
     );
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -358,6 +358,7 @@ const escapeTags = [
   '@elsecustomdirective',
   '@endcustomdirective',
   'x-slot --___\\d+___--',
+  '___attrs_+\\d+___',
 ];
 
 export function checkResult(formatted: any) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/237.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/237

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is an unstable formatting case when blade component including like `name="<="` attribute, it can not format correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
