### PR TITLE
fix: 🐛 unnecessary indent in raw php directive

### DIFF
--- a/__tests__/fixtures/formatted.raw_php_block.blade.php
+++ b/__tests__/fixtures/formatted.raw_php_block.blade.php
@@ -4,7 +4,7 @@
     @foreach ($users as $user)
         @php
             $users = $_GET;
-            
+
             foreach ($users as $key1 => $value) {
                 if (is_array($value)) {
                     foreach ($value as $key2 => $value2) {

--- a/__tests__/fixtures/snapshots/php_block_directive.snapshot
+++ b/__tests__/fixtures/snapshots/php_block_directive.snapshot
@@ -1,0 +1,26 @@
+------------------------------------options----------------------------------------
+{}
+------------------------------------content----------------------------------------
+@php
+    use Eagle\Utilities\Dates\TimeZone;
+    // assert blank line will not be indented
+
+    $timezone_options =
+        ['' => ''] +
+        TimeZone::create()
+            ->format('tz-label')
+            ->countryCodePriority('US')
+            ->get();
+@endphp
+------------------------------------expected----------------------------------------
+@php
+    use Eagle\Utilities\Dates\TimeZone;
+    // assert blank line will not be indented
+
+    $timezone_options =
+        ['' => ''] +
+        TimeZone::create()
+            ->format('tz-label')
+            ->countryCodePriority('US')
+            ->get();
+@endphp

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1357,6 +1357,10 @@ export default class Formatter {
           return prefixForEnd + line;
         }
 
+        if (line.length === 0) {
+          return line;
+        }
+
         return prefix + line;
       })
       .join('\n')


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/239

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/239

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is an unnecessary indent spaces on blank line in `@php` ~ `@endphp` directive

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
