### PR TITLE
fix: 🐛 long props collapse into single line

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5286,4 +5286,28 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('long props', async () => {
+    const content = [
+      `@props(['name', 'title' => 'Please Confirm', 'message' => 'Are you sure?', 'level' => 'info', 'icon' => 'heroicon-o-question-mark-circle', 'cancelButtonText' => 'No', 'cancelButtonType' => 'muted', 'affirmButtonText' => 'Yes', 'affirmButtonType' => 'success', 'affirmButtonDisabled' => false])`,
+    ].join('\n');
+
+    const expected = [
+      `@props([`,
+      `    'name',`,
+      `    'title' => 'Please Confirm',`,
+      `    'message' => 'Are you sure?',`,
+      `    'level' => 'info',`,
+      `    'icon' => 'heroicon-o-question-mark-circle',`,
+      `    'cancelButtonText' => 'No',`,
+      `    'cancelButtonType' => 'muted',`,
+      `    'affirmButtonText' => 'Yes',`,
+      `    'affirmButtonType' => 'success',`,
+      `    'affirmButtonDisabled' => false,`,
+      `])`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5310,4 +5310,32 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('nested long props', async () => {
+    const content = [
+      `<div>`,
+      `@props(['name', 'title' => 'Please Confirm', 'message' => 'Are you sure?', 'level' => 'info', 'icon' => 'heroicon-o-question-mark-circle', 'cancelButtonText' => 'No', 'cancelButtonType' => 'muted', 'affirmButtonText' => 'Yes', 'affirmButtonType' => 'success', 'affirmButtonDisabled' => false])`,
+      `</div>`,
+    ].join('\n');
+
+    const expected = [
+      `<div>`,
+      `    @props([`,
+      `        'name',`,
+      `        'title' => 'Please Confirm',`,
+      `        'message' => 'Are you sure?',`,
+      `        'level' => 'info',`,
+      `        'icon' => 'heroicon-o-question-mark-circle',`,
+      `        'cancelButtonText' => 'No',`,
+      `        'cancelButtonType' => 'muted',`,
+      `        'affirmButtonText' => 'Yes',`,
+      `        'affirmButtonType' => 'success',`,
+      `        'affirmButtonDisabled' => false,`,
+      `    ])`,
+      `</div>`,
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -193,6 +193,7 @@ export default class Formatter {
       .then((target) => this.preserveBladeBrace(target))
       .then((target) => this.preserveRawBladeBrace(target))
       .then((target) => this.preserveConditions(target))
+      .then((target) => this.preservePropsBlock(target))
       .then((target) => this.preserveInlineDirective(target))
       .then((target) => this.preserveInlinePhpDirective(target))
       .then((target) => this.preserveBladeDirectivesInScripts(target))
@@ -1321,7 +1322,6 @@ export default class Formatter {
         `@props(${util
           .formatRawStringAsPhp(this.rawPropsBlocks[p1], {
             ...this.options,
-            printWidth: util.printWidthForInline,
           })
           .trimRight()})`,
     );

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1315,16 +1315,19 @@ export default class Formatter {
 
   async restoreRawPropsBlock(content: any) {
     const regex = this.getRawPropsPlaceholder('(\\d+)');
-    return _.replace(
-      content,
-      new RegExp(regex, 'gms'),
-      (_match: any, p1: any) =>
-        `@props(${util
-          .formatRawStringAsPhp(this.rawPropsBlocks[p1], {
-            ...this.options,
-          })
-          .trimRight()})`,
-    );
+    return _.replace(content, new RegExp(regex, 'gms'), (_match: any, p1: any) => {
+      const placeholder = this.getRawPropsPlaceholder(p1.toString());
+      const matchedLine = content.match(new RegExp(`^(.*?)${placeholder}`, 'gmi')) ?? [''];
+      const indent = detectIndent(matchedLine[0]);
+
+      const formatted = `@props(${util
+        .formatRawStringAsPhp(this.rawPropsBlocks[p1], {
+          ...this.options,
+        })
+        .trim()})`;
+
+      return this.indentRawPhpBlock(indent, formatted);
+    });
   }
 
   isInline(content: any) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes https://github.com/shufo/prettier-plugin-blade/issues/235

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/shufo/prettier-plugin-blade/issues/235

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Long props are not formatted correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
