### PR TITLE
fix: 🐛 unexpected result when attrs are not separated by space

### DIFF
--- a/__tests__/fixtures/snapshots/no_space_quotation.snapshot
+++ b/__tests__/fixtures/snapshots/no_space_quotation.snapshot
@@ -1,0 +1,29 @@
+------------------------------------options----------------------------------------
+{}
+------------------------------------content----------------------------------------
+<button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-1" data-tippy-content="Modifier la prestation"
+            :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'"x-data="{ tippyInstance: null }" x-init="tippyInstance = window.tippy($root)" x-on:click="tippyInstance.hide(); $dispatch('open-prestation-modal', {{ $task->id }})">
+            @include('svg.misc.tag')
+        </button>
+        <button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-1" data-tippy-content="Modifier la durée" :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'" x-data="{ tippyInstance: null }" x-init="tippyInstance = window.tippy($root)" x-on:click="tippyInstance.hide(); $dispatch('open-duration-modal', {{ $task->id }})">
+            @include('svg.misc.extand')
+        </button>
+        <button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-0.5" data-tippy-content="Dupliquer cette tâche" :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'" wire:click="duplicate"x-data="{ tippyInstance: null }" x-init="tippyInstance = window.tippy($root)">
+            @include('svg.misc.duplicate')
+        </button>
+------------------------------------expected----------------------------------------
+<button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-1" data-tippy-content="Modifier la prestation"
+    :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'"x-data="{ tippyInstance: null }"
+    x-init="tippyInstance = window.tippy($root)" x-on:click="tippyInstance.hide(); $dispatch('open-prestation-modal', {{ $task->id }})">
+    @include('svg.misc.tag')
+</button>
+<button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-1" data-tippy-content="Modifier la durée"
+    :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'" x-data="{ tippyInstance: null }"
+    x-init="tippyInstance = window.tippy($root)" x-on:click="tippyInstance.hide(); $dispatch('open-duration-modal', {{ $task->id }})">
+    @include('svg.misc.extand')
+</button>
+<button class="m-2.5 h-5 w-5 scale-125 cursor-pointer p-0.5" data-tippy-content="Dupliquer cette tâche"
+    :class="isHovered && !currently_dragging ? 'opacity-100 delay-50' : 'opacity-0 delay-0'"
+    wire:click="duplicate"x-data="{ tippyInstance: null }" x-init="tippyInstance = window.tippy($root)">
+    @include('svg.misc.duplicate')
+</button>

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -881,7 +881,7 @@ export default class Formatter {
   async preserveHtmlAttributes(content: any) {
     return _.replace(
       content,
-      /(?<=<[\w\-\.\:\_]+[^]*\s)(?!x-bind)([^\s\:][^\s]+\s*=\s*(["'])(?<!\\)[^\2]*?(?<!\\)\2)(?=[^]*(?<!=)\/?>)/gms,
+      /(?<=<[\w\-\.\:\_]+[^]*\s)(?!x-bind)([^\s\:][^\s\'\"]+\s*=\s*(["'])(?<!\\)[^\2]*?(?<!\\)\2)(?=[^]*(?<!=)\/?>)/gms,
       (match: string) => `${this.storeHtmlAttribute(match)}`,
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When html tag attributes are not separated by space like class=""foo="",
formatter will output unexpected result

✅ Closes: #878

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #878

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
