### PR TITLE
fix: 🐛 livewire params is formatted unexpectedly

### DIFF
--- a/__tests__/fixtures/snapshots/livewire_params.snapshot
+++ b/__tests__/fixtures/snapshots/livewire_params.snapshot
@@ -1,0 +1,8 @@
+------------------------------------options----------------------------------------
+{}
+------------------------------------content----------------------------------------
+<livewire:account.messenger.listing :foo="$user"
+                                    :messengers="$messengers"
+                                    :key="messenger-index" />
+------------------------------------expected----------------------------------------
+<livewire:account.messenger.listing :foo="$user" :messengers="$messengers" :key="messenger-index" />

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -2161,6 +2161,10 @@ export default class Formatter {
               return match;
             }
 
+            if (matchedLine[0].startsWith('<livewire')) {
+              return `${p2}${p3}${p4}`;
+            }
+
             if (p2.startsWith('::')) {
               return `${p2}${p3}${beautify
                 .js_beautify(p4, {


### PR DESCRIPTION
## Description
This PR fixes https://github.com/shufo/vscode-blade-formatter/issues/813

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/vscode-blade-formatter/issues/813

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Livewire params should not be formatted by this formatter

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
