### PR TITLE
PROPOSAL/NEED INPUT: feat: add option to use prettier to format HTML

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -253,6 +253,7 @@ export default class Formatter {
       wrap_line_length: util.optional(this.options).wrapLineLength || 120,
       wrap_attributes: util.optional(this.options).wrapAttributes || 'auto',
       wrap_attributes_min_attrs: util.optional(this.options).wrapAttributesMinAttrs,
+      html_formatter: util.optional(this.options).htmlFormatter || 'js_beatify',
       indent_inner_html: util.optional(this.options).indentInnerHtml || false,
       end_with_newline: util.optional(this.options).endWithNewline || true,
       max_preserve_newlines: util.optional(this.options).noMultipleEmptyLines ? 1 : undefined,
@@ -265,7 +266,11 @@ export default class Formatter {
 
     const promise = new Promise((resolve) => resolve(data))
       .then((content) => util.preserveDirectives(content))
-      .then((preserved) => beautify.html_beautify(preserved, options))
+      .then((preserved) =>
+        options.html_formatter === 'prettier'
+          ? util.formatStringAsHtml(preserved, this.options)
+          : beautify.html_beautify(preserved, options),
+      )
       .then((content) => util.revertDirectives(content));
 
     return Promise.resolve(promise);

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ export type FormatterOption = {
   sortTailwindcssClasses?: true;
   tailwindcssConfigPath?: string;
   tailwindcssConfig?: TailwindConfig;
+  htmlFormatter?: string;
   sortHtmlAttributes?: SortHtmlAttributes;
   customHtmlAttributesOrder?: string[] | string;
   noMultipleEmptyLines?: boolean;

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import * as prettier from 'prettier/standalone';
 // @ts-ignore
 // eslint-disable-next-line
 import phpPlugin from '@prettier/plugin-php/standalone';
+import htmlParser from 'prettier/parser-html';
 import detectIndent from 'detect-indent';
 import replaceAsync from 'string-replace-async';
 import { indentStartTokens, phpKeywordEndTokens, phpKeywordStartTokens } from './indent';
@@ -58,6 +59,20 @@ const defaultFormatPhpOption = {
   phpVersion: '8.1',
   noSingleQuote: false,
 };
+
+export async function formatStringAsHtml(content: any, params: FormatPhpOption = {}): Promise<string> {
+  const options = {
+    ...defaultFormatPhpOption,
+    ...params,
+  };
+
+  return prettier.format(content, {
+    parser: 'html',
+    printWidth: options.printWidth,
+    singleQuote: !options.noSingleQuote,
+    plugins: [htmlParser],
+  });
+}
 
 export async function formatStringAsPhp(content: any, params: FormatPhpOption = {}): Promise<string> {
   const options = {


### PR DESCRIPTION
## Description
*This PR is only a draft, but I would like input and/or advice on how to proceed, or if this approach is even desirable.*

This adds the ability to format the HTML markup in templates using the `prettier` HTML parser instead of `js-beautify`.

## Related Issue
I believe that this may address #825, and it may allow issues on the prettier plugin to be resolved as well. For example, https://github.com/shufo/prettier-plugin-blade/issues/260 and https://github.com/shufo/prettier-plugin-blade/issues/249.

## Motivation and Context
As I noted in #909, I usually use this plugin via [shufo/prettier-plugin-blade](https://github.com/shufo/prettier-plugin-blade), and in that context I am formatting *everything* with prettier. It is jarring and unexpected for a prettier plugin to produce output for a "supported" content type that is different from how the core project would format the same content.

**Example HTML-only template**
```html
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim</p>

<input class="mx-auto w-full border rounded" type="text" name="zipID" maxlength="7" required />
```

**Formatted with `blade-formatter --wrap 80`**
```
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim</p>

<input class="mx-auto w-full border rounded" type="text" name="zipID"
    maxlength="7" required />
```

**Formatted with `prettier --parser html`**
```
<p>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
</p>

<input
    class="mx-auto w-full rounded border"
    type="text"
    name="zipID"
    maxlength="7"
    required
/>
```

**Formatted with this PR**
*by default, this PR disables these changes, so I added `options.html_formatter = 'prettier';` on line 267 of `src/formatter.ts` to get this to work.*
```
<p>
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
  incididunt ut labore et dolore magna aliqua. Ut enim ad minim
</p>

<input
  class="mx-auto w-full border rounded"
  type="text"
  name="zipID"
  maxlength="7"
  required
/>
```

I know that this would pose a significant change for the project, so I'd like to discuss it before I dig in too deeply. A few things that cross my mind:
- the current formatter should remain the default, and using `prettier` should be opt-in only
- if this isn't desired for this base project, perhaps it could be opt-in when used within the prettier plugin?

## How Has This Been Tested?
I have only tested this very little. When formatting a simple, HTML-only Blade file. As noted above, this behavior is currently turned off entirely, but can be enabled by adding `options.html_formatter = 'prettier';` on line 267 of `src/formatter.ts`. Note that doing so, though, will cause most tests to fail: `Tests  230 failed | 86 passed (316)` 😄  If you are open to this change, I will spend more time (probably a lot more time!) trying to get it to really work.

## Screenshots (if appropriate):
n/a