### PR TITLE
fix(formatter): correct indent level for raw @php blocks (close #915, #914)

### DIFF
--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5417,4 +5417,54 @@ describe('formatter', () => {
 
     await util.doubleFormatCheck(content, expected);
   });
+
+  test('@php blocks respect indent level for deeply indented code (issue #915)', async () => {
+    let content = [
+      '<div>',
+      '<div>',
+      '<div>',
+      '<div>',
+      '<div>',
+      '<div>',
+      '@php',
+      "$percent = $item['historical'] ?? null ? round((100 * ($item['today'] - $item['historical'])) / $item['historical']) : null;",
+      '',
+      "$color = $percent < 0 ? '#8b0000' : '#006400';",
+      '@endphp',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</div>',
+    ].join('\n');
+
+    // this is slightly different than the code presented in #915 because that
+    // code was wrapped to 80 columns, but these tests all use 120
+    let expected = [
+      '<div>',
+      '    <div>',
+      '        <div>',
+      '            <div>',
+      '                <div>',
+      '                    <div>',
+      '                        @php',
+      '                            $percent =',
+      "                                $item['historical'] ?? null",
+      "                                    ? round((100 * ($item['today'] - $item['historical'])) / $item['historical'])",
+      '                                    : null;',
+      '',
+      "                            $color = $percent < 0 ? '#8b0000' : '#006400';",
+      '                        @endphp',
+      '                    </div>',
+      '                </div>',
+      '            </div>',
+      '        </div>',
+      '    </div>',
+      '</div>',
+      ``,
+    ].join('\n');
+
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1301,8 +1301,7 @@ export default class Formatter {
         } else if (isMultipleStatements) {
           // multiple statments on mult lines
 
-          const indentLevel = (indent.amount + 1) * this.indentSize;
-
+          const indentLevel = indent.amount + this.indentSize;
           rawBlock = (
             await util.formatStringAsPhp(`<?php${rawBlock}?>`, {
               ...this.options,


### PR DESCRIPTION
## Description
When implementing #909, I misunderstood what `indent.amount` represents. I thought it was the number of indent levels, but it's actually the number of indent characters. This corrects that behavior and should improve the formatting of deeply (and not-so-deeply) indented `@php` blocks.

## Related Issue
Fixes #914 and #915

## Motivation and Context
See #915

## How Has This Been Tested?
I added a test, and ran it on several templates.

## Screenshots (if appropriate):
With this change, the code from #915 is formatted as expected: both PHP blocks are formatted identically.
```
@php
    if (1) {
        if (1) {
            if (1) {
                if (1) {
                    if (1) {
                        if (1) {
                            $percent =
                                $item['historical'] ?? null
                                    ? round(
                                        (100 *
                                            ($item['today'] -
                                                $item['historical'])) /
                                            $item['historical'],
                                    )
                                    : null;

                            $color = $percent < 0 ? '#8b0000' : '#006400';
                        }
                    }
                }
            }
        }
    }
@endphp

<div>
    <div>
        <div>
            <div>
                <div>
                    <div>
                        @php
                            $percent =
                                $item['historical'] ?? null
                                    ? round(
                                        (100 *
                                            ($item['today'] -
                                                $item['historical'])) /
                                            $item['historical'],
                                    )
                                    : null;

                            $color = $percent < 0 ? '#8b0000' : '#006400';
                        @endphp
                    </div>
                </div>
            </div>
        </div>
    </div>
</div>
```
