### PR TITLE
feat: add option `--component-prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ e.g.
   "noPhpSyntaxCheck": false,
   "noSingleQuote": false,
   "noTrailingCommaPhp": false,
-  "extraLiners": []
+  "extraLiners": [],
+  "componentPrefix": ["x-", "livewire:"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ $ blade-formatter -c -d resources/**/*.blade.php
       --no-php-syntax-check           Disable PHP syntax checking  [boolean] [default: false]
       --no-trailing-comma-php         If set to true, no trailing commas are printed for php expression.  [boolean] [default: false]
   -p, --progress                      Print progress  [boolean] [default: false]
+  -P, --component-prefix              Specify custom prefixes for component names. This changes the format rules applied to custom components e.g. preserve style in attributes. [string] [default: "x-,livewire:"]
       --stdin                         Format code provided on <STDIN>  [boolean] [default: false]
       --config                        Use this configuration, overriding .bladeformatterrc config options if present  [string] [default: null]
       --ignore-path                   Specify path of ignore file  [string] [default: null]

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1285,6 +1285,32 @@ describe("The blade formatter CLI", () => {
 		expect(cmdResult).toEqual(formatted.toString("utf-8"));
 	});
 
+	test.concurrent("cli argument test (component prefix)", async () => {
+		const cmdResult = await cmd.execute(binPath, [
+			"--component-prefix",
+			'foo:',
+			path.resolve(
+				"__tests__",
+				"fixtures",
+				"argumentTest",
+				"componentPrefix",
+				"index.blade.php",
+			),
+		]);
+
+		const formatted = fs.readFileSync(
+			path.resolve(
+				"__tests__",
+				"fixtures",
+				"argumentTest",
+				"componentPrefix",
+				"formatted.index.blade.php",
+			),
+		);
+
+		expect(cmdResult).toEqual(formatted.toString("utf-8"));
+	});
+
 	test.concurrent("runtime config test (trailing comma php)", async () => {
 		const cmdResult = await cmd.execute(binPath, [
 			path.resolve(

--- a/__tests__/fixtures/argumentTest/componentPrefix/formatted.index.blade.php
+++ b/__tests__/fixtures/argumentTest/componentPrefix/formatted.index.blade.php
@@ -1,0 +1,2 @@
+<foo:button :key="$foo->bar">
+</foo:button>

--- a/__tests__/fixtures/argumentTest/componentPrefix/index.blade.php
+++ b/__tests__/fixtures/argumentTest/componentPrefix/index.blade.php
@@ -1,0 +1,2 @@
+<foo:button :key="$foo->bar">
+</foo:button>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -5612,6 +5612,40 @@ describe("formatter", () => {
 		});
 	});
 
+	test("Without component prefix declared, return syntax incorrect code", async () => {
+		const content = [
+			"<foo:button :key=\"$foo->bar\">",
+			"</foo:button>",
+		].join("\n");
+
+		const expected = [
+			"<foo:button :key=\"$foo - > bar\">",
+			"</foo:button>",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected, {
+			componentPrefix: [],
+		});
+	});
+
+	test("Component prefix option correct format", async () => {
+		const content = [
+			"<foo:button :key=\"$foo->bar\">",
+			"</foo:button>",
+		].join("\n");
+
+		const expected = [
+			"<foo:button :key=\"$foo->bar\">",
+			"</foo:button>",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected, {
+			componentPrefix: ['foo:'],
+		});
+	});
+
 	test("unmatched x-slot close tag", async () => {
 		const content = [
 			"<x-alert>",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,11 +149,11 @@ export default async function cli() {
 			alias: "P",
 			type: "string",
 			description:
-				"Component prefixs use to preserve style in html attributes.",
+				"Component prefix use to preserve style in html attributes.",
 			default: "x-,livewire:",
 			nullable: true,
 			coerce(formats) {
-				// Make sure we support comma-separated syntax: --extra-liners head,body
+				// Make sure we support comma-separated syntax: --component-prefix x-,livewire:
 				return _.flatten(
 					_.flatten([formats]).map((format) => format.split(",")),
 				);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,20 @@ export default async function cli() {
 				);
 			},
 		})
+		.option("component-prefix", {
+			alias: "P",
+			type: "string",
+			description:
+				"Component prefixs use to preserve style in html attributes.",
+			default: "x-,livewire:",
+			nullable: true,
+			coerce(formats) {
+				// Make sure we support comma-separated syntax: --extra-liners head,body
+				return _.flatten(
+					_.flatten([formats]).map((format) => format.split(",")),
+				);
+			},
+		})
 		.option("no-multiple-empty-lines", {
 			type: "boolean",
 			description: "Merge multiple blank lines into a single blank line",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1101,9 +1101,11 @@ export default class Formatter {
 	}
 
 	async preserveComponentAttribute(content: string) {
+		const prefixes = Array.isArray(this.options.componentPrefix) && this.options.componentPrefix.length > 0 ? this.options.componentPrefix : ["x-", "livewire:"];
+		const regex = new RegExp(`(?<=<(${prefixes.join("|")})[^<]*?\\s):{1,2}(?<!=>)[\\w\-_.]*?=(["'])(?!=>)[^\\2]*?\\2(?=[^>]*?\/*?>)`, "gim")
 		return _.replace(
 			content,
-			/(?<=<(x-|livewire:)[^<]*?\s):{1,2}(?<!=>)[\w\-_.]*?=(["'])(?!=>)[^\2]*?\2(?=[^>]*?\/*?>)/gim,
+			regex,
 			(match: any) => `${this.storeComponentAttribute(match)}`,
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ export type FormatterOption = {
 	noSingleQuote?: boolean;
 	noTrailingCommaPhp?: boolean;
 	extraLiners?: string[];
+	componentPrefix?: string[];
 };
 
 export type BladeFormatterOption = CLIOption & FormatterOption;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -42,6 +42,7 @@ export interface RuntimeConfig {
 	noSingleQuote?: boolean;
 	noTrailingCommaPhp?: boolean;
 	extraLiners?: string[];
+	componentPrefix?: string[];
 }
 
 const defaultConfigNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -122,6 +123,12 @@ export async function readRuntimeConfig(
 				nullable: true,
 				items: { type: "string" },
 				default: ["head", "body", "/html"],
+			},
+			componentPrefix: {
+				type: "array",
+				nullable: true,
+				items: { type: "string" },
+				default: ["x-", "livewire:"],
 			},
 		},
 		additionalProperties: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a new option `componentPrefix` for html attr format.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

closes #942 closes #944 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to currently only prefix of `x-` or `livewire:` treat as custom component and format html attr differently, thus for new libs like `flux` which uses prefix of `flux:`. The result of the format will cause a syntex error. e.g. `:key="$foo - > bar"`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Both cli and formatter test cases added. 

## Screenshots (if appropriate):
