### PR TITLE
feat: Front Matter can be ignored from within Blade files

### DIFF
--- a/__tests__/formatter/ignore.test.ts
+++ b/__tests__/formatter/ignore.test.ts
@@ -176,7 +176,7 @@ describe("formatter ignore test", () => {
       "foo: bar",
       "    bar: baz",
       "---",
-		].join("\n");
+    ].join("\n");
 
     const expected = [
       "---",

--- a/__tests__/formatter/ignore.test.ts
+++ b/__tests__/formatter/ignore.test.ts
@@ -102,7 +102,7 @@ describe("formatter ignore test", () => {
 		await util.doubleFormatCheck(content, expected);
 	});
 
-	test("prettier ignore syntax", async () => {
+	test("prettier ignore with html and blade comments", async () => {
 		const content = [
 			"<!-- prettier-ignore-start -->",
 			`<div id="foo-bar-baz"          class="bar-foo-baz" title="a sample title" data-foo="bar" data-bar="baz">`,
@@ -151,6 +151,51 @@ describe("formatter ignore test", () => {
 			"",
 			"{{-- prettier-ignore --}}",
 			`<span id="foo-bar-baz"          class="bar-foo-baz" title="a sample title" data-foo="bar" data-bar="baz" />`,
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+  test("prettier ignore within front matter blocks", async () => {
+		const content = [
+      "---",
+			"# prettier-ignore-start",
+			"foo: bar",
+			"    bar: baz",
+      "# prettier-ignore-end",
+      "---",
+      "",
+      "---",
+			"foo: bar",
+      "# prettier-ignore",
+			"    bar: baz",
+      "---",
+      "",
+      "---",
+			"foo: bar",
+			"    bar: baz",
+      "---",
+		].join("\n");
+
+		const expected = [
+			"---",
+			"# prettier-ignore-start",
+			"foo: bar",
+			"    bar: baz",
+      "# prettier-ignore-end",
+      "---",
+      "",
+      "---",
+			"foo: bar",
+      "# prettier-ignore",
+			"    bar: baz",
+      "---",
+      "",
+      "---",
+			"foo: bar",
+			"bar: baz",
+      "---",
 			"",
 		].join("\n");
 

--- a/__tests__/formatter/ignore.test.ts
+++ b/__tests__/formatter/ignore.test.ts
@@ -158,47 +158,47 @@ describe("formatter ignore test", () => {
 	});
 
   test("prettier ignore within front matter blocks", async () => {
-		const content = [
+    const content = [
       "---",
-			"# prettier-ignore-start",
-			"foo: bar",
-			"    bar: baz",
+      "# prettier-ignore-start",
+      "foo: bar",
+      "    bar: baz",
       "# prettier-ignore-end",
       "---",
       "",
       "---",
-			"foo: bar",
+      "foo: bar",
       "# prettier-ignore",
-			"    bar: baz",
+      "    bar: baz",
       "---",
       "",
       "---",
-			"foo: bar",
-			"    bar: baz",
+      "foo: bar",
+      "    bar: baz",
       "---",
 		].join("\n");
 
-		const expected = [
-			"---",
-			"# prettier-ignore-start",
-			"foo: bar",
-			"    bar: baz",
+    const expected = [
+      "---",
+      "# prettier-ignore-start",
+      "foo: bar",
+      "    bar: baz",
       "# prettier-ignore-end",
       "---",
       "",
       "---",
-			"foo: bar",
+      "foo: bar",
       "# prettier-ignore",
-			"    bar: baz",
+      "    bar: baz",
       "---",
       "",
       "---",
-			"foo: bar",
-			"bar: baz",
+      "foo: bar",
+      "bar: baz",
       "---",
-			"",
-		].join("\n");
+      "",
+    ].join("\n");
 
-		await util.doubleFormatCheck(content, expected);
-	});
+    await util.doubleFormatCheck(content, expected);
+  });
 });

--- a/src/processors/ignoredLinesProcessor.ts
+++ b/src/processors/ignoredLinesProcessor.ts
@@ -23,12 +23,12 @@ export class IgnoredLinesProcessor extends Processor {
 				)
 				// range ignore
 				.replace(
-					/(?:({{--\s*?blade-formatter-disable\s*?--}}|<!--\s*?prettier-ignore-start\s*?-->|{{--\s*?prettier-ignore-start\s*?--}})).*?(?:({{--\s*?blade-formatter-enable\s*?--}}|<!--\s*?prettier-ignore-end\s*?-->|{{--\s*?prettier-ignore-end\s*?--}}))/gis,
+					/(?:(#\s*?blade-formatter-disable|{{--\s*?blade-formatter-disable\s*?--}}|#\s*?prettier-ignore-start|<!--\s*?prettier-ignore-start\s*?-->|{{--\s*?prettier-ignore-start\s*?--}})).*?(?:(#\s*?blade-formatter-enable|{{--\s*?blade-formatter-enable\s*?--}}|#\s*?prettier-ignore-end|<!--\s*?prettier-ignore-end\s*?-->|{{--\s*?prettier-ignore-end\s*?--}}))/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
 				// line ignore
 				.replace(
-					/(?:{{--\s*?blade-formatter-disable-next-line\s*?--}}|{{--\s*?prettier-ignore\s*?--}}|<!--\s*?prettier-ignore\s*?-->)[\r\n]+[^\r\n]+/gis,
+					/(?:#\s*?blade-formatter-disable-next-line|{{--\s*?blade-formatter-disable-next-line\s*?--}}|#\s*?prettier-ignore|{{--\s*?prettier-ignore\s*?--}}|<!--\s*?prettier-ignore\s*?-->)[\r\n]+[^\r\n]+/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
 				.value()

--- a/src/processors/ignoredLinesProcessor.ts
+++ b/src/processors/ignoredLinesProcessor.ts
@@ -23,12 +23,12 @@ export class IgnoredLinesProcessor extends Processor {
 				)
 				// range ignore
 				.replace(
-					/(?:(#\s*?blade-formatter-disable|{{--\s*?blade-formatter-disable\s*?--}}|#\s*?prettier-ignore-start|<!--\s*?prettier-ignore-start\s*?-->|{{--\s*?prettier-ignore-start\s*?--}})).*?(?:(#\s*?blade-formatter-enable|{{--\s*?blade-formatter-enable\s*?--}}|#\s*?prettier-ignore-end|<!--\s*?prettier-ignore-end\s*?-->|{{--\s*?prettier-ignore-end\s*?--}}))/gis,
+					/(?:({{--\s*?blade-formatter-disable\s*?--}}|#\s*?prettier-ignore-start|<!--\s*?prettier-ignore-start\s*?-->|{{--\s*?prettier-ignore-start\s*?--}})).*?(?:({{--\s*?blade-formatter-enable\s*?--}}|#\s*?prettier-ignore-end|<!--\s*?prettier-ignore-end\s*?-->|{{--\s*?prettier-ignore-end\s*?--}}))/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
 				// line ignore
 				.replace(
-					/(?:#\s*?blade-formatter-disable-next-line|{{--\s*?blade-formatter-disable-next-line\s*?--}}|#\s*?prettier-ignore|{{--\s*?prettier-ignore\s*?--}}|<!--\s*?prettier-ignore\s*?-->)[\r\n]+[^\r\n]+/gis,
+					/(?:{{--\s*?blade-formatter-disable-next-line\s*?--}}|#\s*?prettier-ignore|{{--\s*?prettier-ignore\s*?--}}|<!--\s*?prettier-ignore\s*?-->)[\r\n]+[^\r\n]+/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
 				.value()


### PR DESCRIPTION
When using [Jigsaw](https://github.com/tighten/jigsaw) from Tighten, we leverage YAML Front Matter from within [Blade files](https://github.com/tighten/jigsaw-blog-template/blob/main/source/blog.blade.php) in order to enrich template files.

## Description

When using this formatter alongside the [Prettier plugin](https://github.com/shufo/prettier-plugin-blade), it will try to format Front Matter parts, and corrupt it.

```blade
---
title: Blog
description: The list of blog posts for the site
pagination:
    collection: posts
    perPage: 4
---

@extends('_layouts.main')
```

will become

```blade
---
title: Blog
description: The list of blog posts for the site
pagination:
collection: posts
perPage: 4
---

@extends('_layouts.main')
```

but the indentation is important with YAML, therefore the Front Matter section becomes invalid.

## Motivation and Context

We would like to be able to use `prettier-ignore-start`, `prettier-ignore-end`, `prettier-ignore`, `blade-formatter-disable-next-line`, `blade-formatter-enable` and `blade-formatter-disable` from within Front Matter YAML comments, so this formatter can ignore it and keeps formatting the Blade file underneath the Front Matter block.

This way we could have:

```blade
---
# prettier-ignore-start
title: Blog
description: The list of blog posts for the site
pagination:
    collection: posts
    perPage: 4
# prettier-ignore-end
---

@extends('_layouts.main')
```

## How Has This Been Tested?

- Threw unit tests here
- When using it on a vanilla Blade file
- When using it on a Blade file with a Front Matter block
