### PR TITLE
fix: ignore Front Matter blocks

### DIFF
--- a/__tests__/formatter/ignore.test.ts
+++ b/__tests__/formatter/ignore.test.ts
@@ -102,6 +102,35 @@ describe("formatter ignore test", () => {
 		await util.doubleFormatCheck(content, expected);
 	});
 
+	test("ignore formatting within front matter blocks", async () => {
+		const content = [
+			"---",
+			"foo: bar",
+			"    bar: baz",
+			"---",
+			`@section('body')`,
+			"    @if ($user)",
+			"    {{ $user->name }}",
+			"    @endif",
+			"@endsection",
+		].join("\n");
+
+		const expected = [
+			"---",
+			"foo: bar",
+			"    bar: baz",
+			"---",
+			`@section('body')`,
+			"    @if ($user)",
+			"        {{ $user->name }}",
+			"    @endif",
+			"@endsection",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
 	test("prettier ignore syntax", async () => {
 		const content = [
 			"<!-- prettier-ignore-start -->",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "codecov": "^3.8.3",
     "cross-env": "^7.0.3",
     "esbuild": "^0.24.0",
-    "esbuild-node-externals": "^1.4.1",
+    "esbuild-node-externals": "^1.16.0",
     "fs-extra": "^11.0.0",
     "husky": "^8.0.0",
     "lint-staged": ">=10",

--- a/src/processors/ignoredLinesProcessor.ts
+++ b/src/processors/ignoredLinesProcessor.ts
@@ -31,6 +31,11 @@ export class IgnoredLinesProcessor extends Processor {
 					/(?:{{--\s*?blade-formatter-disable-next-line\s*?--}}|{{--\s*?prettier-ignore\s*?--}}|<!--\s*?prettier-ignore\s*?-->)[\r\n]+[^\r\n]+/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
+				// ignore Front Matter blocks
+				.replace(
+					/^(?:(---)).*?(?:(---))/gis,
+					(match: any) => this.storeIgnoredLines(match),
+				)
 				.value()
 		);
 	}

--- a/src/processors/ignoredLinesProcessor.ts
+++ b/src/processors/ignoredLinesProcessor.ts
@@ -33,7 +33,7 @@ export class IgnoredLinesProcessor extends Processor {
 				)
 				// ignore Front Matter blocks
 				.replace(
-					/^(?:(---)).*?(?:(---))/gis,
+					/^---\r?\n[\s\S]*?\r?\n---(?=(\r?\n))/gis,
 					(match: any) => this.storeIgnoredLines(match),
 				)
 				.value()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,13 +2800,13 @@ es-module-lexer@^1.6.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
   integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
 
-esbuild-node-externals@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/esbuild-node-externals/-/esbuild-node-externals-1.4.1.tgz#7f8602c32791c113c70efef433eac55477136e29"
-  integrity sha512-ZFNGa6w1kYzn4wx9ty4eaItaOTSe2hWQZ6WXa/8guKJCiXL3XpW2CZT4gkx2OhfBKxpqaqa7ZeGK54ScoLSUdw==
+esbuild-node-externals@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/esbuild-node-externals/-/esbuild-node-externals-1.16.0.tgz#803a3b1720c9ea65a11304cab23b8cc951c3c4aa"
+  integrity sha512-g16pp/yDFqBJ9/9D+UIWPj5uC8MPslMK62HmAXW+ZomZWJifOFTuJgado86UUiMeBrk03z2uvdS6cIGi0OTRcg==
   dependencies:
-    find-up "5.0.0"
-    tslib "2.3.1"
+    find-up "^5.0.0"
+    tslib "^2.4.1"
 
 esbuild@^0.24.0:
   version "0.24.0"
@@ -3165,14 +3165,6 @@ find-config@^1.0.0:
   dependencies:
     user-home "^2.0.0"
 
-find-up@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -3186,6 +3178,14 @@ find-up@^4.1.0:
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 flat-cache@^3.0.4:
@@ -5560,10 +5560,15 @@ ts-node@^10.4.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-tslib@2.3.1, tslib@^2.0.1, tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
When using [Jigsaw](https://github.com/tighten/jigsaw) from Tighten, we leverage YAML Front Matter from within [Blade files](https://github.com/tighten/jigsaw-blog-template/blob/main/source/blog.blade.php) in order to enrich template files. This block is always at the start of the file.

## Description

When using this formatter alongside the [Prettier plugin](https://github.com/shufo/prettier-plugin-blade), it will try to format Front Matter parts, and corrupt it.

```blade
---
title: Blog
description: The list of blog posts for the site
pagination:
    collection: posts
    perPage: 4
---

@extends('_layouts.main')
```

will become

```blade
---
title: Blog
description: The list of blog posts for the site
pagination:
collection: posts
perPage: 4
---

@extends('_layouts.main')
```

but the indentation is important with YAML, therefore the Front Matter block becomes invalid.

## Motivation and Context

We would like the formatter to ignore Front Matter blocks.

## How Has This Been Tested?

- Threw unit tests here
- When using it on a vanilla Blade file
- When using it on a Blade file with a Front Matter block

## Misc

Bumping `esbuild-node-externals` to prevent npm to crash when running `npm install`.

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/6814f65e-6b7d-4b85-99d8-6c1752b63d33" />

Both `npm install` and `yarn install` mention `"Found 123 errors in 44 files."` FYI
