### PR TITLE
fix: 🐛 unexpected indent on break directive inside if directive

### DIFF
--- a/__tests__/formatter/builtin-directives.test.ts
+++ b/__tests__/formatter/builtin-directives.test.ts
@@ -867,4 +867,12 @@ describe("formatter builtin directives test", () => {
 			sortHtmlAttributes: "idiomatic",
 		});
 	});
+
+	test("@if-@break structure", async () => {
+		const content = ["@if ($user)", "    @break", "@endif"].join("\n");
+
+		const expected = ["@if ($user)", "    @break", "@endif", ""].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -127,6 +127,13 @@ export default class Formatter {
 			return;
 		}
 
+		// if @break is inside @if, decrement indent after @break
+		if (_.last(this.stack) === "@if" && token === "@break") {
+			this.shouldBeIndent = false;
+
+			return;
+		}
+
 		if (_.includes(phpKeywordEndTokens, token)) {
 			if (token === "@break") {
 				this.decrementIndentLevel();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- refs: #941

This PR fixes indenting problem that `@break` directive inside `@if` directive gets unexpected indenting.

e.g.

```blade
@if ($user)
    @break
@endif
```

Current behaviour after formatting.

```blade
@if ($user)
@break
@endif
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- fixes: #941

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should not be indented like laravel's official blade description for `@break` directive.

```blade
@foreach ($users as $user)
    @if ($condition)
        @break
    @endif
@endforeach
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

passing tests.
