### PR TITLE
fix: 🐛 `@js` directive in script tag replaced as undefined

### DIFF
--- a/__tests__/formatter/js.test.ts
+++ b/__tests__/formatter/js.test.ts
@@ -1,0 +1,48 @@
+import { describe, test } from "vitest";
+import * as util from "../support/util";
+
+describe("formatter js test", () => {
+	test("basic @js directive usage", async () => {
+		const content = [`<div x-data="@js($data, JSON_FORCE_OBJECT)"></div>`].join(
+			"\n",
+		);
+
+		const expected = [
+			`<div x-data="@js($data, JSON_FORCE_OBJECT)"></div>`,
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+	test("@js directive in script tag", async () => {
+		const content = [
+			"<script>",
+			"    @foreach ($files as $file)",
+			"        addUpload(",
+			"            @js($file->id),",
+			"            @js($file->name),",
+			"            @js($file->hash),",
+			"            $('#article_inline_uploads')",
+			"        );",
+			"    @endforeach",
+			"</script>",
+		].join("\n");
+
+		const expected = [
+			"<script>",
+			"    @foreach ($files as $file)",
+			"        addUpload(",
+			"            @js($file->id),",
+			"            @js($file->name),",
+			"            @js($file->hash),",
+			"            $('#article_inline_uploads')",
+			"        );",
+			"    @endforeach",
+			"</script>",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+});

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -146,6 +146,7 @@ export const inlinePhpDirectives = [
 export const inlineFunctionTokens = [
 	"@set",
 	"@json",
+	"@js",
 	"@selected",
 	"@checked",
 	"@disabled",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes <https://github.com/shufo/prettier-plugin-blade/issues/305>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- <https://github.com/shufo/prettier-plugin-blade/issues/305>

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`@js` directive introduced in laravel 8.x should be supported

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

passing the tests
