### PR TITLE
If it is a PHP expression (contains ->), it does not format it

### DIFF
--- a/src/processors/shorthandBindingProcessor.ts
+++ b/src/processors/shorthandBindingProcessor.ts
@@ -46,7 +46,7 @@ export class ShorthandBindingProcessor extends Processor {
 							brace_style: "preserve-inline",
 						};
 
-						if (p4 === "") {
+						if (p4 === "" || p4.includes('->')) {
 							return match;
 						}
 


### PR DESCRIPTION
## Description
The recoveryShorthandBinding function has been updated to prevent automatic formatting of expressions containing the -> operator, commonly used in PHP.

## Related Issue (https://github.com/shufo/blade-formatter/issues/1001)
> ### Template before formatting
> :param="auth()->user->name"
> ### Template after formatting
> :param="auth() - > user - > name"
> ### Expected Behaviour
> :param="auth()->user->name"

## Motivation and Context
The formatter previously attempted to format expressions containing PHP syntax (->), which resulted in incorrect formatting or unexpected behavior. This change ensures that such expressions are preserved as-is and not passed through the JS beautifier.