### PR TITLE
fix: 🐛 inline directive in script replaced to unexpected token

### DIFF
--- a/__tests__/formatter/scripts.test.ts
+++ b/__tests__/formatter/scripts.test.ts
@@ -553,4 +553,49 @@ describe("formatter scripts test", () => {
 			"Can't format blade",
 		);
 	});
+
+	// see: https://github.com/shufo/vscode-blade-formatter/issues/967
+	test("it should handle custom directives in scripts", async () => {
+		const content = [
+			`@extends('layouts.parent-layout')`,
+			``,
+			`@section('scripts')`,
+			`    <script>`,
+			`        $(document).ready(function() {`,
+			`            @foo('submitSuccessInit',`,
+			`            2,`,
+			`            new Foo()->bar())`,
+			``,
+			`            @if (request('token'))`,
+			`              foo`,
+			`            @else`,
+			`              bar`,
+			`            @endif`,
+			`        });`,
+			`    </script>`,
+			``,
+			`@endsection`,
+		].join("\n");
+
+		const expected = [
+			`@extends('layouts.parent-layout')`,
+			``,
+			`@section('scripts')`,
+			`    <script>`,
+			`        $(document).ready(function() {`,
+			`            @foo('submitSuccessInit', 2, new Foo()->bar())`,
+			``,
+			`            @if (request('token'))`,
+			`                foo`,
+			`            @else`,
+			`                bar`,
+			`            @endif`,
+			`        });`,
+			`    </script>`,
+			`@endsection`,
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
 });

--- a/src/processors/bladeDirectiveInScriptsProcessor.ts
+++ b/src/processors/bladeDirectiveInScriptsProcessor.ts
@@ -237,6 +237,9 @@ export class BladeDirectiveInScriptsProcessor extends Processor {
 			);
 		});
 
+		// restore inline custom directive
+		result = await this.restoreInlineCustomDirective(result);
+
 		result = await replaceAsync(
 			result,
 			/(?<=<script[^>]*?(?<!=)>)(.*?)(?=<\/script>)/gis,
@@ -368,6 +371,52 @@ export class BladeDirectiveInScriptsProcessor extends Processor {
 		return result;
 	}
 
+	/**
+	 * restore inline custom directives
+	 */
+	async restoreInlineCustomDirective(content: string) {
+		return replaceAsync(
+			content,
+			new RegExp(
+				`${this.getInlineCustomDirectivePlaceholder("(\\d+)")}`,
+				"gim",
+			),
+			async (_match: any, p1: number) => {
+				const placeholder = this.getInlineCustomDirectivePlaceholder(
+					p1.toString(),
+				);
+				const matchedLine = content.match(
+					new RegExp(`^(.*?)${_.escapeRegExp(placeholder)}`, "gmi"),
+				) ?? [""];
+				const indent = detectIndent(matchedLine[0]);
+
+				const matched = `${this.customDirectives[p1]}`;
+
+				return replaceAsync(
+					matched,
+					/(@[a-zA-z0-9\-_]+)(.*)/gis,
+					async (match2: string, p2: string, p3: string) => {
+						try {
+							const formatted = (
+								await util.formatRawStringAsPhp(`func${p3}`, {
+									...this.formatter.options,
+									printWidth: util.printWidthForInline,
+								})
+							)
+								.replace(/([\n\s]*)->([\n\s]*)/gs, "->")
+								.replace(/,(\s*?\))$/gm, (_m, p4) => p4)
+								.trim()
+								.substring(4);
+							return `${p2}${util.indentComponentAttribute(indent.indent, formatted, this.formatter)}`;
+						} catch (_error) {
+							return `${match2}`;
+						}
+					},
+				);
+			},
+		);
+	}
+
 	storeBladeDirective(value: any) {
 		return this.getBladeDirectivePlaceholder(
 			this.bladeDirectives.push(value) - 1,
@@ -453,7 +502,7 @@ export class BladeDirectiveInScriptsProcessor extends Processor {
 	}
 
 	getInlineCustomDirectivePlaceholder(replace: string) {
-		return _.replace("___inline_cd_#___", "#", replace);
+		return _.replace("___inline_cdis_#___", "#", replace);
 	}
 
 	preserveStringLiteralInPhp(content: any) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes <https://github.com/shufo/vscode-blade-formatter/issues/967>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

- <https://github.com/shufo/vscode-blade-formatter/issues/967>

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Inline directive in script tag should be formatted as expected.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see added test
