### PR TITLE
fix: symbolic link is missing in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /app
 ADD . /app
 COPY --from=builder /app/dist /app/dist
 RUN yarn install --production
-RUN ln -s $(pwd)/bin/blade-formatter /usr/local/bin/blade-formatter
+RUN ln -s $(pwd)/bin/blade-formatter.js /usr/local/bin/blade-formatter
 
 ENTRYPOINT ["blade-formatter"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ $ yarn global add blade-formatter
 
 ```bash
 $ docker run -it -v $(pwd):/app -w /app shufo/blade-formatter resources/**/*.blade.php
+# From stdin
+$ cat test.blade.php | docker run -i shufo/blade-formatter --stdin
 ```
 
 ## Usage


### PR DESCRIPTION
- **fix: 🐛 symbolic link missing**
- **docs: ✏️ add description for stdin input for docker**

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- closes: #1088

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- see: #1088

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

build and run docker image local
