### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
     "type": "git",
     "url": "https://github.com/shufo/blade-formatter.git"
   },
+  "homepage": "https://github.com/shufo/blade-formatter#readme",
+  "bugs": {
+    "url": "https://github.com/shufo/blade-formatter/issues"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
## Summary

- add the standard npm `homepage` metadata pointing to the repository README
- add `bugs.url` so registry clients can link directly to the issue tracker
- keep the patch metadata-only with no formatter, dependency, export, or build changes

Closes #1108

## Validation

- CommonJS main and CLI builds passed
- ESM main and CLI builds passed
- Biome lint passed (existing repository warnings only)
- `pnpm pack --dry-run --json`
- direct Node assertions for both metadata values
- `git diff --check`

## Test environment note

I also ran the Vitest suite on Windows. It executes, but fixture expectations consistently use LF while formatter output follows the Windows CRLF default, causing broad snapshot/assertion failures unrelated to this `package.json`-only change. The repository's Linux CI should provide the authoritative full-suite result.