### PR TITLE
Feat: Expose js-beautify options for embedded scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,24 @@ e.g.
   "noTrailingCommaPhp": false,
   "extraLiners": [],
   "componentPrefix": ["x-", "livewire:"],
-  "phpVersion": "8.4"
+  "phpVersion": "8.4",
+  "jsBeautify": {
+    "space_after_anon_function": true,
+    "space_in_paren": false,
+    "brace_style": "collapse",
+    "break_chained_methods": false,
+    "keep_array_indentation": false
+  }
 }
 ```
 
 blade-formatter will search up the directory structure until it reaches the root directory.
+
+### Formatting embedded `<script>` blocks
+
+The JavaScript inside `<script>` blocks is formatted with [js-beautify](https://github.com/beautifier/js-beautify). The `jsBeautify` option is an object passed straight through to js-beautify, so you can control the embedded-script style. Any keys you omit fall back to js-beautify's defaults, so leaving `jsBeautify` unset keeps the current behaviour. See the [js-beautify options](https://github.com/beautifier/js-beautify#options) for the full list.
+
+Indentation and line width for `<script>` blocks are already derived from blade-formatter's own `indentSize` and `wrapLineLength` options, so prefer those rather than the js-beautify equivalents.
 
 ## Ignore Files
 

--- a/__tests__/formatter/jsBeautify.test.ts
+++ b/__tests__/formatter/jsBeautify.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert";
+import { describe, test } from "vitest";
+import { Formatter } from "../../src/main.js";
+
+const scriptContent = [
+	"<script>",
+	"btn.addEventListener('click', function() {",
+	"    doThing();",
+	"});",
+	"</script>",
+	"",
+].join("\n");
+
+describe("jsBeautify option", () => {
+	test("forwards js-beautify options to embedded <script> blocks", () => {
+		return new Formatter({ jsBeautify: { space_after_anon_function: true } })
+			.formatContent(scriptContent)
+			.then((result: any) => {
+				assert.ok(
+					result.includes("function () {"),
+					"expected a space after the anonymous function keyword",
+				);
+				assert.ok(!result.includes("function() {"));
+			});
+	});
+
+	test("uses js-beautify defaults when the option is omitted", () => {
+		return new Formatter({})
+			.formatContent(scriptContent)
+			.then((result: any) => {
+				assert.ok(
+					result.includes("function() {"),
+					"expected js-beautify's default (no space) to be preserved",
+				);
+			});
+	});
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ export type FormatterOption = {
 	extraLiners?: string[];
 	componentPrefix?: string[];
 	phpVersion?: string;
+	jsBeautify?: Record<string, unknown>;
 };
 
 export type BladeFormatterOption = CLIOption & FormatterOption;

--- a/src/processors/formatAsHtmlProcessor.ts
+++ b/src/processors/formatAsHtmlProcessor.ts
@@ -27,6 +27,7 @@ export class FormatAsHtmlProcessor extends Processor {
 				? 1
 				: undefined,
 			extra_liners: util.optional(this.formatter.options).extraLiners,
+			js: util.optional(this.formatter.options).jsBeautify || {},
 			css: {
 				end_with_newline: false,
 			},

--- a/src/processors/scriptsProcessor.ts
+++ b/src/processors/scriptsProcessor.ts
@@ -52,6 +52,7 @@ export class ScriptsProcessor extends Processor {
 						extra_liners: util.optional(this.formatter.options).extraLiners,
 						indent_with_tabs: useTabs,
 						end_with_newline: false,
+						js: util.optional(this.formatter.options).jsBeautify || {},
 						templating: ["php"],
 					};
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -43,6 +43,7 @@ export interface RuntimeConfig {
 	noTrailingCommaPhp?: boolean;
 	extraLiners?: string[];
 	componentPrefix?: string[];
+	jsBeautify?: Record<string, unknown>;
 }
 
 const defaultConfigNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -129,6 +130,12 @@ export async function readRuntimeConfig(
 				nullable: true,
 				items: { type: "string" },
 				default: ["x-", "livewire:"],
+			},
+			jsBeautify: {
+				type: "object",
+				nullable: true,
+				required: [],
+				additionalProperties: true,
 			},
 		},
 		additionalProperties: true,


### PR DESCRIPTION
## Description
Adds a `jsBeautify` option that is passed straight through to [js-beautify](https://github.com/beautifier/js-beautify), which formats the JavaScript inside `<script>` blocks.

- `RuntimeConfig` and `FormatterOption` gain `jsBeautify?: Record<string, unknown>` (with a schema entry).
- It is spread into the `js` sub-object of the `html_beautify` options in both `FormatAsHtmlProcessor` (whole-document pass) and `ScriptsProcessor` (script/tag pass).
- Omitting it falls back to js-beautify's defaults, so existing behaviour is unchanged.

Configurable via `.bladeformatterrc.json` or the API:
```json
{ "jsBeautify": { "space_after_anon_function": true } }
```

## Related Issue
Closes #1112 

## Motivation and Context
The motivation for doing this is that our code standards apply consistent style conventions across both PHP and JS. For example, a space after the function keyword (as PSR-12 requires for PHP closures); we want the same in JavaScript, but it's not currently possible without these changes.

Embedded `<script>` blocks are formatted by js-beautify's `html_beautify`, but its JS sub-options were never configurable; the `js` key on the beautify options was never set, so the defaults couldn't be overridden. For example, there was no way to format anonymous functions as `function ()` (with a space) inside `<script>` blocks. This exposes js-beautify's options for embedded scripts while leaving the default output unchanged.

## How Has This Been Tested?
Yeah:
- Added `__tests__/formatter/jsBeautify.test.ts`: asserts the option adds the space (`function () {`) and that the default (option omitted) is unchanged (`function() {`).
- Ran the formatter and snapshot suites with vitest on Node 20: 250 tests pass. Worth mentioning, you've got a failing test (`inlined.test.ts` › "should consider directive in html tag") that also fails on a clean `main`, so it's pre-existing and unrelated to these changes.

## Screenshots (if appropriate):
N/A