### PR TITLE
fix: 🐛 single quote in a @php block comment strips indentation

### DIFF
--- a/__tests__/formatter/php.test.ts
+++ b/__tests__/formatter/php.test.ts
@@ -548,4 +548,99 @@ describe("formatter php test", () => {
 
 		await util.doubleFormatCheck(content, expected);
 	});
+
+	test("@php block keeps indentation when a line comment contains a single quote", async () => {
+		const content = [
+			"@php",
+			"    // it's here",
+			"    $a = 'x';",
+			"@endphp",
+		].join("\n");
+
+		const expected = [
+			"@php",
+			"    // it's here",
+			"    $a = 'x';",
+			"@endphp",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+	test("@php block keeps indentation when a hash comment contains a single quote", async () => {
+		const content = [
+			"@php",
+			"    # it's here",
+			"    $a = 'x';",
+			"@endphp",
+		].join("\n");
+
+		const expected = [
+			"@php",
+			"    # it's here",
+			"    $a = 'x';",
+			"@endphp",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+	test("@php block keeps indentation when a block comment contains a single quote", async () => {
+		const content = [
+			"@php",
+			"    /* it's here */",
+			"    $a = 'x';",
+			"@endphp",
+		].join("\n");
+
+		const expected = [
+			"@php",
+			"    /* it's here */",
+			"    $a = 'x';",
+			"@endphp",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+	test("@php block keeps indentation when a comment contains an unpaired double quote", async () => {
+		const content = [
+			"@php",
+			'    // he said "hello',
+			'    $a = "x$b";',
+			"@endphp",
+		].join("\n");
+
+		const expected = [
+			"@php",
+			'    // he said "hello',
+			'    $a = "x$b";',
+			"@endphp",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
+
+	test("@php block does not treat a comment marker inside a string as a comment", async () => {
+		const content = [
+			"@php",
+			"    $a = '// not a comment';",
+			"    $b = 'y';",
+			"@endphp",
+		].join("\n");
+
+		const expected = [
+			"@php",
+			"    $a = '// not a comment';",
+			"    $b = 'y';",
+			"@endphp",
+			"",
+		].join("\n");
+
+		await util.doubleFormatCheck(content, expected);
+	});
 });

--- a/src/processors/phpBlockProcessor.ts
+++ b/src/processors/phpBlockProcessor.ts
@@ -5,6 +5,10 @@ import replaceAsync from "string-replace-async";
 import * as util from "../util";
 import { Processor } from "./processor";
 
+function isPhpComment(token: string): boolean {
+	return /^(\/\*|\/\/|#)/.test(token);
+}
+
 export class PhpBlockProcessor extends Processor {
 	private rawBlocks: string[] = [];
 	private rawPropsBlocks: string[] = [];
@@ -116,8 +120,9 @@ export class PhpBlockProcessor extends Processor {
 	preserveStringLiteralInPhp(content: any) {
 		return _.replace(
 			content,
-			/(\"([^\\]|\\.)*?\"|\'([^\\]|\\.)*?\')/gm,
-			(match: string) => `${this.storeStringLiteralInPhp(match)}`,
+			/(\/\*[\s\S]*?\*\/|\/\/[^\n]*|#(?!\[)[^\n]*|\"([^\\]|\\.)*?\"|\'([^\\]|\\.)*?\')/gm,
+			(match: string) =>
+				isPhpComment(match) ? match : `${this.storeStringLiteralInPhp(match)}`,
 		);
 	}
 


### PR DESCRIPTION
- fix: :bug: single quote in a `@php` block comment strips indentation
- test: :ring: add tests for quotes in `@php` block comments

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A comment inside a `@php` block that contains an odd number of quote characters makes every
following line lose its indentation, up to the next matching quote.

```blade
@php
    // it's here
    $a = 'x';
@endphp
```

was format into

```blade
@php
    // it's here
$a = 'x';
@endphp
```

All three comment styles are affected (`//`, `#`, `/* */`), and an unpaired double quote behaves
the same way. The damage runs until the next matching quote, so it can flatten a whole block.

`preserveStringLiteralInPhp()` swaps string literals for placeholders so `indentRawBlock()`
cannot indent into them, but its regex has no notion of comments. `[^\\]` matches newlines, so an
unpaired `'` in a comment pairs with the next `'` further down the block. That multi-line span
collapses into a single-line placeholder, so those lines no longer exist as lines when the indent
pass runs and never receive a prefix; `restoreStringLiteralInPhp()` then splices the original text
back in verbatim.

The fix matches comments in the same alternation, ahead of the string literals, and returns them
untouched. Leftmost-match semantics keep this correct in both directions: a `//` inside a string is
still consumed by the string branch, and a quote inside a comment by the comment branch. Block
comments now reach `preservePhpComment()` intact, which is the pass meant to handle them.
`#(?!\[)` keeps PHP 8 attributes out.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

- fixes: https://github.com/shufo/blade-formatter/issues/REPLACE_WITH_ISSUE_NUMBER

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It fails silently: no warning, no error, the file is just reported as changed. Running the
formatter in a lint/fix step writes the broken indentation to disk and commits it, and
re-indenting by hand does not help because the next run flattens it again, which reads like a
merge artifact rather than a formatter bug.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Five tests added to `__tests__/formatter/php.test.ts`, all using `doubleFormatCheck` so
idempotency is covered: the three comment styles, an unpaired double quote, and a regression guard
that `$a = '// not a comment';` is still treated as a string, not a comment. The first four fail on
`main` and pass with this change; the guard passes both ways by design.

Full suite: 342 passed (337 before, plus these 5).

### Not covered

Heredoc bodies share the root cause:

```blade
@php
    $a = <<<TXT
    it's here
    TXT;
    $b = 'y';
@endphp
```

I left this out deliberately: heredocs are a different token class, and preserving them here would
also change what `indentRawBlock()` currently does to heredoc bodies (it indents them, which alters
the string value). That seemed to deserve its own discussion rather than riding along on a comment
fix. Happy to send a follow-up if you would like it addressed.

## Screenshots (if appropriate):

n/a
